### PR TITLE
Validate only the primary certificate domain

### DIFF
--- a/wildcard_cert/main.tf
+++ b/wildcard_cert/main.tf
@@ -24,11 +24,11 @@ resource "aws_acm_certificate_validation" "domain" {
   validation_record_fqdns = ["${var.domain}"]
 }
 
+# Only need to validate the first record because the wildcard entry will use the same DNS record
 resource "aws_route53_record" "validation" {
-  count   = "${length(aws_acm_certificate.domain.domain_validation_options)}"
-  name    = "${lookup(aws_acm_certificate.domain.domain_validation_options[count.index], "resource_record_name")}"
-  type    = "${lookup(aws_acm_certificate.domain.domain_validation_options[count.index], "resource_record_type")}"
+  name    = "${aws_acm_certificate.domain.domain_validation_options.0.resource_record_name}"
+  type    = "${aws_acm_certificate.domain.domain_validation_options.0.resource_record_type}"
   zone_id = "${data.aws_route53_zone.external.id}"
-  records = ["${lookup(aws_acm_certificate.domain.domain_validation_options[count.index], "resource_record_value")}"]
+  records = ["${aws_acm_certificate.domain.domain_validation_options.0.resource_record_value}"]
   ttl     = 60
 }


### PR DESCRIPTION
We only need to the validate the primary DNS entry here, not the wildcard, because they both use the same DNS record. Adding just the apex domain validation will cover both. Duh.