### PR TITLE
Fix to get completely working Teleport setup via AMI

### DIFF
--- a/ami/playbooks/base.yml
+++ b/ami/playbooks/base.yml
@@ -8,31 +8,6 @@
         name: '*'
         state: latest
 
-    - name: install teleport binaries
-      copy:
-        src: files/teleport/{{item}}
-        dest: /usr/local/bin/
-      with_items:
-        - tctl
-        - teleport
-        - teleport-secrets
-
-    - name: install teleport configurations
-      copy:
-        src: files/teleport/{{item}}
-        dest: /etc/
-      with_items:
-        - teleport.yaml
-
-    - name: install teleport systemd units
-      copy:
-        src: files/teleport/{{item}}
-        dest: /etc/systemd/system/
-      with_items:
-        - teleport.service
-        - teleport_proxy.service
-        - teleport_auth.service
-
     - name: Add the teleport user
       user:
         name: teleport
@@ -46,14 +21,38 @@
 
     - name: Create directories for Teleport files
       file:
-        path: "{{ item }}"
+        path: /var/lib/teleport
         state: directory
         mode: 0755
         owner: teleport
         group: adm
+
+    - name: install teleport binaries
+      copy:
+        src: files/teleport/{{item}}
+        dest: /usr/local/bin/
+        owner: teleport
+        group: adm
+        mode: 0755
       with_items:
-        - /var/run/teleport
-        - /var/lib/teleport
+        - tctl
+        - teleport
+        - teleport-secrets
+
+    - name: install teleport configuration
+      copy:
+        src: files/teleport/teleport.yaml
+        dest: /etc/
+        mode: 0644
+
+    - name: install teleport systemd units
+      copy:
+        src: files/teleport/{{item}}
+        dest: /etc/systemd/system/
+      with_items:
+        - teleport.service
+        - teleport_proxy.service
+        - teleport_auth.service
 
     - name: install packages
       yum:

--- a/ami/playbooks/base.yml
+++ b/ami/playbooks/base.yml
@@ -56,8 +56,20 @@
 
     - name: install packages
       yum:
-        name: [curl, git, jq, docker]
+        name: [curl, git, jq, docker, yum-cron]
         state: present
+
+    - name: install yum-cron config for security updates
+      copy:
+        src: files/yum-cron.conf
+        dest: /etc/yum
+        mode: 0644
+
+    - name: add ec2-user to docker group
+      user:
+        name: ec2-user
+        append: yes
+        groups: docker
 
     - name: enable services
       service:
@@ -66,9 +78,4 @@
       with_items:
         - docker
         - teleport
-
-    - name: add ec2-user to docker group
-      user:
-        name: ec2-user
-        append: yes
-        groups: docker
+        - yum-cron

--- a/ami/playbooks/files/teleport/teleport-secrets
+++ b/ami/playbooks/files/teleport/teleport-secrets
@@ -2,6 +2,7 @@
 
 # Setup teleport auth server config file
 INSTANCE_ID=$(curl -sSf http://169.254.169.254/latest/meta-data/instance-id)
+PRIVATE_IP=$(curl -sSf http://169.254.169.254/latest/meta-data/local-ipv4)
 REGION=$(curl -sSf http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//')
 ENVIRONMENT=$(aws ec2 describe-tags --region "$REGION" --filters "Name=resource-id,Values=${INSTANCE_ID}" | jq '.Tags | .[] | select(.Key | contains("env")) | .Value ' | cut -f 2 -d '"')
 SECRET_ID="${ENVIRONMENT}/teleport/cluster_token"
@@ -9,5 +10,6 @@ SECRET_ID="${ENVIRONMENT}/teleport/cluster_token"
 NODENAME=$(aws ec2 describe-tags --region "$REGION" --filters "Name=resource-id,Values=${INSTANCE_ID}" | jq '.Tags | .[] | select(.Key | contains("Name")) | .Value ' | cut -f 2 -d '"')
 CLUSTER_TOKEN=$(aws secretsmanager get-secret-value --region "$REGION" --secret-id ${SECRET_ID} | jq ".SecretString" | cut -f 2 -d '"')
 
+sed -i "s/{{ private_ip }}/${PRIVATE_IP}/g" /etc/teleport.yaml
 sed -i "s/{{ nodename }}/${NODENAME}/g" /etc/teleport.yaml
 sed -i "s/{{ cluster_token }}/${CLUSTER_TOKEN}/g" /etc/teleport.yaml

--- a/ami/playbooks/files/teleport/teleport-secrets
+++ b/ami/playbooks/files/teleport/teleport-secrets
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 # Setup teleport auth server config file
-INSTANCE_ID=$(curl http://169.254.169.254/latest/meta-data/instance-id)
-ENVIRONMENT=$(aws ec2 describe-tags --filters "Name=resource-id,Values=${INSTANCE_ID}" | jq '.Tags | .[] | select(.Key | contains("env")) | .Value ' | cut -f 2 -d '"')
+INSTANCE_ID=$(curl -sSf http://169.254.169.254/latest/meta-data/instance-id)
+REGION=$(curl -sSf http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//')
+ENVIRONMENT=$(aws ec2 describe-tags --region "$REGION" --filters "Name=resource-id,Values=${INSTANCE_ID}" | jq '.Tags | .[] | select(.Key | contains("env")) | .Value ' | cut -f 2 -d '"')
 SECRET_ID="${ENVIRONMENT}/teleport/cluster_token"
 
-NODENAME=$(aws ec2 describe-tags --filters "Name=resource-id,Values=${INSTANCE_ID}" | jq '.Tags | .[] | select(.Key | contains("Name")) | .Value ' | cut -f 2 -d '"')
-CLUSTER_TOKEN=$(aws secretsmanager get-secret-value --secret-id ${SECRET_ID} | jq ".SecretString" | cut -f 2 -d '"')
+NODENAME=$(aws ec2 describe-tags --region "$REGION" --filters "Name=resource-id,Values=${INSTANCE_ID}" | jq '.Tags | .[] | select(.Key | contains("Name")) | .Value ' | cut -f 2 -d '"')
+CLUSTER_TOKEN=$(aws secretsmanager get-secret-value --region "$REGION" --secret-id ${SECRET_ID} | jq ".SecretString" | cut -f 2 -d '"')
 
 sed -i "s/{{ nodename }}/${NODENAME}/g" /etc/teleport.yaml
 sed -i "s/{{ cluster_token }}/${CLUSTER_TOKEN}/g" /etc/teleport.yaml

--- a/ami/playbooks/files/teleport/teleport.service
+++ b/ami/playbooks/files/teleport/teleport.service
@@ -6,6 +6,7 @@ After=network.target
 Type=simple
 Restart=always
 RestartSec=5
+RuntimeDirectory=teleport
 ExecStartPre=/usr/local/bin/teleport-secrets
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport.yaml --diag-addr=0.0.0.0:3434 --insecure-no-tls
 ExecReload=/bin/kill -HUP \$MAINPID

--- a/ami/playbooks/files/teleport/teleport.yaml
+++ b/ami/playbooks/files/teleport/teleport.yaml
@@ -2,6 +2,7 @@ teleport:
   nodename: {{ nodename }}
   data_dir: /var/lib/teleport
   pid_file: /var/run/teleport.pid
+  advertise_ip: {{ private_ip }}
   auth_token: {{ cluster_token }}
   auth_servers:
   - auth.teleport.local:3025

--- a/ami/playbooks/files/teleport/teleport_auth.service
+++ b/ami/playbooks/files/teleport/teleport_auth.service
@@ -8,6 +8,7 @@ Group=adm
 Type=simple
 Restart=always
 RestartSec=5
+RuntimeDirectory=teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport_auth.yaml --diag-addr=0.0.0.0:3434 --insecure-no-tls
 ExecReload=/bin/kill -HUP \$MAINPID
 PIDFile=/var/run/teleport/teleport.pid

--- a/ami/playbooks/files/teleport/teleport_proxy.service
+++ b/ami/playbooks/files/teleport/teleport_proxy.service
@@ -8,6 +8,7 @@ Group=adm
 Type=simple
 Restart=always
 RestartSec=5
+RuntimeDirectory=teleport
 ExecStart=/usr/local/bin/teleport start --config=/etc/teleport_proxy.yaml --diag-addr=0.0.0.0:3434 --insecure-no-tls
 ExecReload=/bin/kill -HUP \$MAINPID
 PIDFile=/var/run/teleport/teleport.pid

--- a/ami/playbooks/files/yum-cron.conf
+++ b/ami/playbooks/files/yum-cron.conf
@@ -1,0 +1,83 @@
+[commands]
+#  What kind of update to use:
+# default                            = yum upgrade
+# security                           = yum --security upgrade
+# security-severity:Critical         = yum --sec-severity=Critical upgrade
+# minimal                            = yum --bugfix update-minimal
+# minimal-security                   = yum --security update-minimal
+# minimal-security-severity:Critical =  --sec-severity=Critical update-minimal
+update_cmd = security
+
+# Whether a message should be emitted when updates are available,
+# were downloaded, or applied.
+update_messages = yes
+
+# Whether updates should be downloaded when they are available.
+download_updates = yes
+
+# Whether updates should be applied when they are available.  Note
+# that download_updates must also be yes for the update to be applied.
+apply_updates = yes
+
+# Maximum amout of time to randomly sleep, in minutes.  The program
+# will sleep for a random amount of time between 0 and random_sleep
+# minutes before running.  This is useful for e.g. staggering the
+# times that multiple systems will access update servers.  If
+# random_sleep is 0 or negative, the program will run immediately.
+#  NOTE that we hold up all the other things in cron.daily as we wait,
+# so while waiting for 6+ hours is fine for us it might not be nice
+# for logrotate (so wait for 2 hours by default).
+random_sleep = 120
+
+
+[emitters]
+# Name to use for this system in messages that are emitted.  If
+# system_name is None, the hostname will be used.
+system_name = None
+
+# How to send messages.  Valid options are stdio and email.  If
+# emit_via includes stdio, messages will be sent to stdout; this is useful
+# to have cron send the messages.  If emit_via includes email, this
+# program will send email itself according to the configured options.
+# If emit_via is None or left blank, no messages will be sent.
+emit_via = stdio
+
+# The width, in characters, that messages that are emitted should be
+# formatted to.
+output_width = 80
+
+
+[email]
+# The address to send email messages from.
+# NOTE: 'localhost' will be replaced with the value of system_name.
+email_from = root@localhost
+
+# List of addresses to send messages to.
+email_to = root
+
+# Name of the host to connect to to send email messages.
+email_host = localhost
+
+
+[groups]
+# NOTE: This only works when group_command != objects, which is now the default
+# List of groups to update
+group_list = None
+
+# The types of group packages to install
+group_package_types = mandatory, default
+
+[base]
+# This section overrides yum.conf
+
+# Use this to filter Yum core messages
+# -4: critical
+# -3: critical+errors
+# -2: critical+errors+warnings (default)
+debuglevel = -2
+
+# skip_broken = True
+mdpolicy = group:main
+
+# Uncomment to auto-import new gpg keys (dangerous)
+# assumeyes = True

--- a/encryptkey/main.tf
+++ b/encryptkey/main.tf
@@ -3,6 +3,7 @@ resource "aws_kms_key" "main" {
   deletion_window_in_days = 10
   enable_key_rotation     = true
 
+  # TODO(bob) Factor out the hard-coded accounts
   policy = <<POLICY
   {
   "Version": "2012-10-17",

--- a/plain_instance/data.tf
+++ b/plain_instance/data.tf
@@ -38,6 +38,14 @@ data "aws_security_group" "jumpbox" {
   }
 }
 
+data "aws_secretsmanager_secret" "cluster_token" {
+  name = "${var.env}/teleport/cluster_token"
+}
+
+data "aws_kms_alias" "main" {
+  name = "alias/${var.env}-main"
+}
+
 data "aws_ami" "base" {
   most_recent = true
   owners      = ["self"]

--- a/plain_instance/main.tf
+++ b/plain_instance/main.tf
@@ -129,7 +129,7 @@ EOF
 
 resource "aws_kms_grant" "main" {
   name              = "${env}-${application_name}-main"
-  key_id            = "${data.aws_kms_alias.main.target_key.arn}"
+  key_id            = "${data.aws_kms_alias.main.target_key_arn}"
   grantee_principal = "${aws_iam_role.iam.arn}"
   operations        = ["Decrypt"]
 }

--- a/plain_instance/main.tf
+++ b/plain_instance/main.tf
@@ -119,13 +119,8 @@ resource "aws_iam_policy" "teleport_secrets" {
         },
         {
             "Effect": "Allow",
-            "Action": [
-              "kms:Encrypt",
-              "kms:Decrypt"
-            ],
-            "Resource": [
-              "${data.aws_kms_alias.main.arn}"
-          ]
+            "Action": "kms:Decrypt",
+            "Resource": "${data.aws_kms_alias.main.target_key_arn}"
         }
     ]
 }

--- a/plain_instance/main.tf
+++ b/plain_instance/main.tf
@@ -92,15 +92,15 @@ EOF
 }
 
 # Give it base teleport permissions
-resource "aws_iam_role_policy_attachment" "worker_teleport" {
-  role       = "${aws_iam_role.worker.name}"
+resource "aws_iam_role_policy_attachment" "iam_teleport" {
+  role       = "${aws_iam_role.iam.name}"
   policy_arn = "${aws_iam_policy.teleport_secrets.arn}"
 }
 
 ### Shared IAM role for teleport
 resource "aws_iam_policy" "teleport_secrets" {
-  name        = "jenkins-teleport-secrets"
-  path        = "/${var.env}/jenkins/"
+  name        = "instance-teleport-secrets"
+  path        = "/${var.env}/plain-instance/"
   description = "Allows nodes to run local teleport daemon"
 
   policy = <<EOF
@@ -125,4 +125,11 @@ resource "aws_iam_policy" "teleport_secrets" {
     ]
 }
 EOF
+}
+
+resource "aws_kms_grant" "main" {
+  name              = "${env}-${application_name}-main"
+  key_id            = "${data.aws_kms_alias.main.target_key.arn}"
+  grantee_principal = "${aws_iam_role.iam.arn}"
+  operations        = ["Decrypt"]
 }

--- a/plain_instance/outputs.tf
+++ b/plain_instance/outputs.tf
@@ -1,3 +1,8 @@
 output "app_sg_id" {
   value = "${module.base.app_sg_id}"
 }
+
+output "instance_iam_role" {
+  description = "IAM role name for attaching additional policies to the instance with aws_iam_role_policy_attachment"
+  value       = "${aws_iam_role.iam.name}"
+}

--- a/plain_instance/variables.tf
+++ b/plain_instance/variables.tf
@@ -39,8 +39,3 @@ variable "user_data" {
   description = "OPTIONAL: user data script to run on initialization"
   default     = ""
 }
-
-variable "instance_role" {
-  description = "OPTIONAL: IAM instance role to provide to the application"
-  default     = ""
-}

--- a/utilities/jenkins/data.tf
+++ b/utilities/jenkins/data.tf
@@ -34,6 +34,10 @@ data "aws_route53_zone" "internal" {
   private_zone = true
 }
 
+data "aws_secretsmanager_secret" "cluster_token" {
+  name = "${var.env}/teleport/cluster_token"
+}
+
 data "aws_ami" "base" {
   most_recent = true
   owners      = ["self"]

--- a/utilities/jenkins/data.tf
+++ b/utilities/jenkins/data.tf
@@ -38,6 +38,10 @@ data "aws_secretsmanager_secret" "cluster_token" {
   name = "${var.env}/teleport/cluster_token"
 }
 
+data "aws_kms_alias" "main" {
+  name = "alias/${var.env}-main"
+}
+
 data "aws_ami" "base" {
   most_recent = true
   owners      = ["self"]

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -432,13 +432,8 @@ resource "aws_iam_policy" "teleport_secrets" {
         },
         {
             "Effect": "Allow",
-            "Action": [
-              "kms:Encrypt",
-              "kms:Decrypt"
-            ],
-            "Resource": [
-              "${data.aws_kms_alias.main.arn}"
-          ]
+            "Action": "kms:Decrypt",
+            "Resource": "${data.aws_kms_alias.main.target_key_arn}"
         }
     ]
 }

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -383,7 +383,7 @@ resource "aws_iam_role_policy_attachment" "primary_teleport" {
 ### Worker
 resource "aws_iam_instance_profile" "worker" {
   name = "${var.env}-jenkins-worker"
-  role = "${aws_iam_role.primary.name}"
+  role = "${aws_iam_role.worker.name}"
 }
 
 # Auth instance profile and roles
@@ -429,6 +429,16 @@ resource "aws_iam_policy" "teleport_secrets" {
             "Effect": "Allow",
             "Action": "secretsmanager:GetSecretValue",
             "Resource": "${data.aws_secretsmanager_secret.cluster_token.arn}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+              "kms:Encrypt",
+              "kms:Decrypt"
+            ],
+            "Resource": [
+              "${data.aws_kms_alias.main.arn}"
+          ]
         }
     ]
 }

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -145,6 +145,8 @@ resource "aws_instance" "jenkins_primary" {
   subnet_id                   = "${element(data.aws_subnet.application_subnet.*.id,1)}"
   vpc_security_group_ids      = ["${aws_security_group.jenkins_primary.id}"]
 
+  iam_instance_profile = "${aws_iam_instance_profile.primary.name}"
+
   user_data = <<-EOF
               #!/bin/bash
               docker run -d --restart always \
@@ -263,7 +265,7 @@ resource "aws_instance" "jenkins_worker" {
   ami                  = "${data.aws_ami.base.id}"
   instance_type        = "t2.micro"
   key_name             = "infrastructure"
-  iam_instance_profile = "${var.worker_iam_profile}"
+  iam_instance_profile = "${aws_iam_instance_profile.worker.name}"
 
   associate_public_ip_address = false
   subnet_id                   = "${element(data.aws_subnet.application_subnet.*.id,count.index)}" #distribute instances across AZs
@@ -342,4 +344,93 @@ resource "aws_security_group_rule" "worker_egress" {
   cidr_blocks = ["0.0.0.0/0"]
 
   security_group_id = "${aws_security_group.jenkins_worker.id}"
+}
+
+#######
+# IAM accesses
+#######
+
+### Primary
+resource "aws_iam_instance_profile" "primary" {
+  name = "${var.env}-jenkins-primary"
+  role = "${aws_iam_role.primary.name}"
+}
+
+# Auth instance profile and roles
+resource "aws_iam_role" "primary" {
+  name = "${var.env}-jenkins-primary"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"Service": "ec2.amazonaws.com"},
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+# Give it base teleport permissions
+resource "aws_iam_role_policy_attachment" "primary_teleport" {
+  role       = "${aws_iam_role.primary.name}"
+  policy_arn = "${aws_iam_policy.teleport_secrets.arn}"
+}
+
+### Worker
+resource "aws_iam_instance_profile" "worker" {
+  name = "${var.env}-jenkins-worker"
+  role = "${aws_iam_role.primary.name}"
+}
+
+# Auth instance profile and roles
+resource "aws_iam_role" "worker" {
+  name = "${var.env}-jenkins-worker"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"Service": "ec2.amazonaws.com"},
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+# Give it base teleport permissions
+resource "aws_iam_role_policy_attachment" "worker_teleport" {
+  role       = "${aws_iam_role.worker.name}"
+  policy_arn = "${aws_iam_policy.teleport_secrets.arn}"
+}
+
+### Shared IAM role for teleport
+resource "aws_iam_policy" "teleport_secrets" {
+  name        = "teleport-secrets"
+  path        = "${var.env}/teleport"
+  description = "Allows nodes to run local teleport daemon"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect" : "Allow",
+            "Action" : "ec2:DescribeTags",
+            "Resource" : "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "secretsmanager:GetSecretValue",
+            "Resource": "${data.aws_secretsmanager_secret.cluster_token.arn}"
+        }
+    ]
+}
+EOF
 }

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -413,7 +413,7 @@ resource "aws_iam_role_policy_attachment" "worker_teleport" {
 ### Shared IAM role for teleport
 resource "aws_iam_policy" "teleport_secrets" {
   name        = "teleport-secrets"
-  path        = "${var.env}/jenkins/"
+  path        = "/${var.env}/jenkins/"
   description = "Allows nodes to run local teleport daemon"
 
   policy = <<EOF

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -413,10 +413,10 @@ resource "aws_iam_role_policy_attachment" "worker_teleport" {
 ### Shared IAM role for teleport
 resource "aws_iam_policy" "teleport_secrets" {
   name        = "teleport-secrets"
-  path        = "${var.env}/teleport"
+  path        = "${var.env}/jenkins"
   description = "Allows nodes to run local teleport daemon"
 
-  assume_role_policy = <<EOF
+  policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -413,7 +413,7 @@ resource "aws_iam_role_policy_attachment" "worker_teleport" {
 ### Shared IAM role for teleport
 resource "aws_iam_policy" "teleport_secrets" {
   name        = "teleport-secrets"
-  path        = "${var.env}/jenkins"
+  path        = "${var.env}/jenkins/"
   description = "Allows nodes to run local teleport daemon"
 
   policy = <<EOF

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -442,7 +442,7 @@ EOF
 
 resource "aws_kms_grant" "primary" {
   name              = "jenkins-primary-main"
-  key_id            = "${data.aws_kms_alias.main.target_key.arn}"
+  key_id            = "${data.aws_kms_alias.main.target_key_arn}"
   grantee_principal = "${aws_iam_role.primary.arn}"
   operations        = ["Decrypt"]
 }

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -439,3 +439,17 @@ resource "aws_iam_policy" "teleport_secrets" {
 }
 EOF
 }
+
+resource "aws_kms_grant" "primary" {
+  name              = "jenkins-primary-main"
+  key_id            = "${data.aws_kms_alias.main.target_key.arn}"
+  grantee_principal = "${aws_iam_role.primary.arn}"
+  operations        = ["Decrypt"]
+}
+
+resource "aws_kms_grant" "worker" {
+  name              = "jenkins-worker-main"
+  key_id            = "${data.aws_kms_alias.main.target_key.arn}"
+  grantee_principal = "${aws_iam_role.worker.arn}"
+  operations        = ["Decrypt"]
+}

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -449,7 +449,7 @@ resource "aws_kms_grant" "primary" {
 
 resource "aws_kms_grant" "worker" {
   name              = "jenkins-worker-main"
-  key_id            = "${data.aws_kms_alias.main.target_key.arn}"
+  key_id            = "${data.aws_kms_alias.main.target_key_arn}"
   grantee_principal = "${aws_iam_role.worker.arn}"
   operations        = ["Decrypt"]
 }

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -412,7 +412,7 @@ resource "aws_iam_role_policy_attachment" "worker_teleport" {
 
 ### Shared IAM role for teleport
 resource "aws_iam_policy" "teleport_secrets" {
-  name        = "teleport-secrets"
+  name        = "jenkins-teleport-secrets"
   path        = "/${var.env}/jenkins/"
   description = "Allows nodes to run local teleport daemon"
 

--- a/utilities/jenkins/variables.tf
+++ b/utilities/jenkins/variables.tf
@@ -11,6 +11,11 @@ variable "num_workers" {
   default     = 2
 }
 
+variable "num_executors" {
+  description = "How many execution slots per node"
+  default     = 4
+}
+
 variable "jumpbox_sg" {
   description = "OPTIONAL: the security group of any jumpbox to provide SSH access"
   default     = ""

--- a/utilities/jenkins/variables.tf
+++ b/utilities/jenkins/variables.tf
@@ -6,19 +6,9 @@ variable "domain_name" {
   description = "the external domain name for reaching the public resources. must have a certificate in ACM associated with it."
 }
 
-variable "worker_iam_profile" {
-  description = "the IAM instance profile to be used on the worker nodes"
-  default     = ""
-}
-
 variable "num_workers" {
   description = "How many worker nodes to create"
   default     = 2
-}
-
-variable "num_executors" {
-  description = "How many execution slots per node"
-  default     = 4
 }
 
 variable "jumpbox_sg" {

--- a/utilities/main.tf
+++ b/utilities/main.tf
@@ -4,7 +4,7 @@ module "jumpbox" {
   domain_name = "${var.domain_name}"
 
   # Turned off by default
-  enabled = false
+  enabled = "${var.jumpbox_enabled}"
 }
 
 module "teleport" {

--- a/utilities/outputs.tf
+++ b/utilities/outputs.tf
@@ -1,4 +1,4 @@
 output "worker_iam_role" {
   description = "IAM role name for attaching additional policies for the worker with aws_iam_role_policy_attachment"
-  value       = "${aws_iam_role.worker.name}"
+  value       = "${module.jenkins.worker_iam_role}"
 }

--- a/utilities/teleport/auth-user-data.tmpl
+++ b/utilities/teleport/auth-user-data.tmpl
@@ -57,11 +57,12 @@ spec:
       logins:
         - ec2-user
 EOF
-chown -R teleport:adm /var/lib/teleport
 
-# Stop the local node service
+# Stop the local default services
 systemctl disable --now teleport
+systemctl disable --now docker
 
+chown -R teleport:adm /var/lib/teleport
 # Start daemon and endure through restarts
 systemctl enable --now teleport_auth
 

--- a/utilities/teleport/auth-user-data.tmpl
+++ b/utilities/teleport/auth-user-data.tmpl
@@ -67,7 +67,9 @@ chown -R teleport:adm /var/lib/teleport
 systemctl enable --now teleport_auth
 
 echo "Create GitHub authenticator"
-# Sleep to allow time for the authentication service to start up
-sleep 20 && sudo -u teleport /usr/local/bin/tctl create /var/lib/teleport/github.yaml
+
+# Sleep to allow time for the authentication service to start up and then retry a few times
+sleep 15
+for i in {1..5}; do sudo -u teleport /usr/local/bin/tctl create /var/lib/teleport/github.yaml && break || sleep 15; done
 
 echo "Teleport install complete"

--- a/utilities/teleport/auth.tf
+++ b/utilities/teleport/auth.tf
@@ -24,11 +24,14 @@ resource "aws_lb" "auth" {
   }
 }
 
+# Must use target type IP to allow auth instances to call back through the LB
+# https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-troubleshooting.html
 resource "aws_lb_target_group" "auth" {
   name_prefix = "telep-"
   port        = 3025
   protocol    = "TCP"
   vpc_id      = "${data.aws_vpc.vpc.id}"
+  target_type = "ip"
 
   depends_on = ["aws_lb.auth"]
 
@@ -107,7 +110,7 @@ resource "aws_instance" "auths" {
 resource "aws_lb_target_group_attachment" "auth" {
   count            = "${var.auth_count}"
   target_group_arn = "${aws_lb_target_group.auth.arn}"
-  target_id        = "${element(aws_instance.auths.*.id,count.index)}"
+  target_id        = "${element(aws_instance.auths.*.private_ip,count.index)}"
 }
 
 #######

--- a/utilities/teleport/auth.tf
+++ b/utilities/teleport/auth.tf
@@ -136,13 +136,13 @@ resource "aws_security_group_rule" "auth_webui" {
   security_group_id = "${aws_security_group.auths.id}"
 }
 
-# Allow it to talk out only to the VPC
+# Allow it to talk to any address to be able to hit AWS APIs for Dynamo, S3
 resource "aws_security_group_rule" "auth_egress" {
   type        = "egress"
   from_port   = 0
   to_port     = 0
   protocol    = "-1"
-  cidr_blocks = ["${data.aws_vpc.vpc.cidr_block}"]
+  cidr_blocks = ["0.0.0.0/0"]
 
   security_group_id = "${aws_security_group.auths.id}"
 }

--- a/utilities/teleport/auth.tf
+++ b/utilities/teleport/auth.tf
@@ -322,12 +322,6 @@ resource "aws_iam_role" "auth" {
 EOF
 }
 
-# Give it base teleport permissions
-resource "aws_iam_role_policy_attachment" "auth_teleport" {
-  role       = "${aws_iam_role.auth.name}"
-  policy_arn = "${aws_iam_policy.teleport_secrets.arn}"
-}
-
 // Auth server uses DynamoDB as a backend, and this is to allow read/write from the dynamo tables
 resource "aws_iam_role_policy" "auth_dynamo" {
   name = "${var.env}-teleport-auth-dynamo"

--- a/utilities/teleport/data.tf
+++ b/utilities/teleport/data.tf
@@ -51,6 +51,10 @@ data "aws_secretsmanager_secret" "cluster_token" {
   name = "${var.env}/teleport/cluster_token"
 }
 
+data "aws_kms_alias" "main" {
+  name = "alias/${var.env}-main"
+}
+
 data "aws_ami" "base" {
   most_recent = true
   owners      = ["self"]

--- a/utilities/teleport/data.tf
+++ b/utilities/teleport/data.tf
@@ -47,6 +47,10 @@ data "aws_secretsmanager_secret_version" "github_secret" {
   secret_id = "${var.env}/teleport/github_secret"
 }
 
+data "aws_secretsmanager_secret" "cluster_token" {
+  name = "${var.env}/teleport/cluster_token"
+}
+
 data "aws_ami" "base" {
   most_recent = true
   owners      = ["self"]

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -73,6 +73,16 @@ resource "aws_iam_policy" "teleport_secrets" {
             "Effect": "Allow",
             "Action": "secretsmanager:GetSecretValue",
             "Resource": "${data.aws_secretsmanager_secret.cluster_token.arn}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+              "kms:Encrypt",
+              "kms:Decrypt"
+            ],
+            "Resource": [
+              "${data.aws_kms_alias.main.arn}"
+          ]
         }
     ]
 }

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -54,37 +54,3 @@ resource "aws_secretsmanager_secret_version" "cluster_token" {
   secret_id     = "${var.env}/teleport/cluster_token"
   secret_string = "${random_string.cluster_token.result}"
 }
-
-resource "aws_iam_policy" "teleport_secrets" {
-  name        = "temp-teleport-secrets"
-  path        = "/${var.env}/teleport/"
-  description = "Allows nodes to run local teleport daemon"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect" : "Allow",
-            "Action" : "ec2:DescribeTags",
-            "Resource" : "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": "secretsmanager:GetSecretValue",
-            "Resource": "${data.aws_secretsmanager_secret.cluster_token.arn}"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-              "kms:Encrypt",
-              "kms:Decrypt"
-            ],
-            "Resource": [
-              "${data.aws_kms_alias.main.arn}"
-          ]
-        }
-    ]
-}
-EOF
-}

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -54,3 +54,27 @@ resource "aws_secretsmanager_secret_version" "cluster_token" {
   secret_id     = "${var.env}/teleport/cluster_token"
   secret_string = "${random_string.cluster_token.result}"
 }
+
+resource "aws_iam_policy" "teleport_secrets" {
+  name        = "teleport-secrets"
+  path        = "${var.env}/teleport"
+  description = "Allows nodes to run local teleport daemon"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect" : "Allow",
+            "Action" : "ec2:DescribeTags",
+            "Resource" : "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": "secretsmanager:GetSecretValue",
+            "Resource": "${data.aws_secretsmanager_secret.cluster_token.arn}"
+        }
+    ]
+}
+EOF
+}

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -57,7 +57,7 @@ resource "aws_secretsmanager_secret_version" "cluster_token" {
 
 resource "aws_iam_policy" "teleport_secrets" {
   name        = "teleport-secrets"
-  path        = "${var.env}/teleport"
+  path        = "${var.env}/teleport/"
   description = "Allows nodes to run local teleport daemon"
 
   policy = <<EOF

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -60,7 +60,7 @@ resource "aws_iam_policy" "teleport_secrets" {
   path        = "${var.env}/teleport"
   description = "Allows nodes to run local teleport daemon"
 
-  assume_role_policy = <<EOF
+  policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -57,7 +57,7 @@ resource "aws_secretsmanager_secret_version" "cluster_token" {
 
 resource "aws_iam_policy" "teleport_secrets" {
   name        = "teleport-secrets"
-  path        = "${var.env}/teleport/"
+  path        = "/${var.env}/teleport/"
   description = "Allows nodes to run local teleport daemon"
 
   policy = <<EOF

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -56,7 +56,7 @@ resource "aws_secretsmanager_secret_version" "cluster_token" {
 }
 
 resource "aws_iam_policy" "teleport_secrets" {
-  name        = "teleport-secrets"
+  name        = "temp-teleport-secrets"
   path        = "/${var.env}/teleport/"
   description = "Allows nodes to run local teleport daemon"
 

--- a/utilities/teleport/proxy-user-data.tmpl
+++ b/utilities/teleport/proxy-user-data.tmpl
@@ -27,9 +27,11 @@ proxy_service:
   public_addr: ${proxy_domain}
 EOF
 
-# Stop the local node service
+# Stop the local default services
 systemctl disable --now teleport
+systemctl disable --now docker
 
+chown -R teleport:adm /var/lib/teleport
 # Start daemon and endure through restarts
 systemctl enable --now teleport_proxy.service
 

--- a/utilities/teleport/proxy.tf
+++ b/utilities/teleport/proxy.tf
@@ -32,6 +32,14 @@ resource "aws_elb" "proxy" {
     ssl_certificate_id = "${module.cert.arn}"
   }
 
+  listener {
+    instance_port      = 3080
+    instance_protocol  = "tcp"
+    lb_port            = 3080
+    lb_protocol        = "ssl"
+    ssl_certificate_id = "${module.cert.arn}"
+  }
+
   health_check {
     healthy_threshold   = 2
     unhealthy_threshold = 2
@@ -69,6 +77,16 @@ resource "aws_security_group_rule" "lb_webui_ingress" {
   type        = "ingress"
   from_port   = 443
   to_port     = 443
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.proxy_lb.id}"
+}
+
+resource "aws_security_group_rule" "lb_client_ingress" {
+  type        = "ingress"
+  from_port   = 3080
+  to_port     = 3080
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 

--- a/utilities/teleport/proxy.tf
+++ b/utilities/teleport/proxy.tf
@@ -115,7 +115,8 @@ resource "aws_instance" "proxies" {
   instance_type = "t3.micro"
   key_name      = "${var.key_pair}"
 
-  user_data = "${element(data.template_file.user_data.*.rendered, count.index)}"
+  iam_instance_profile = "${aws_iam_instance_profile.proxy.name}"
+  user_data            = "${element(data.template_file.user_data.*.rendered, count.index)}"
 
   associate_public_ip_address = false
   subnet_id                   = "${element(data.aws_subnet.application_subnet.*.id,count.index)}" #distribute instances across AZs
@@ -201,4 +202,37 @@ resource "aws_security_group_rule" "jumpbox_proxy" {
   source_security_group_id = "${var.jumpbox_sg}"
 
   security_group_id = "${aws_security_group.proxies.id}"
+}
+
+#######
+# IAM accesses for the instance
+#######
+
+resource "aws_iam_instance_profile" "proxy" {
+  name = "${var.env}-teleport-proxy"
+  role = "${aws_iam_role.proxy.name}"
+}
+
+// Auth instance profile and roles
+resource "aws_iam_role" "proxy" {
+  name = "${var.env}-teleport-proxy"
+
+  assume_role_policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {"Service": "ec2.amazonaws.com"},
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
+}
+
+# Give it base teleport permissions
+resource "aws_iam_role_policy_attachment" "proxy_teleport" {
+  role       = "${aws_iam_role.proxy.name}"
+  policy_arn = "${aws_iam_policy.teleport_secrets.arn}"
 }

--- a/utilities/variables.tf
+++ b/utilities/variables.tf
@@ -5,3 +5,8 @@ variable "env" {
 variable "domain_name" {
   description = "the external domain name for reaching the public resources. must have a certificate in ACM associated with it."
 }
+
+variable "jumpbox_enabled" {
+  description = "OPTIONAL: whether or not to enable the jumpbox"
+  default     = "false"
+}


### PR DESCRIPTION
This PR gets us to a working SSH bastion that is deployed locally onto instances via an AMI so we don't require user-data or ansible to get SSH access!

- Adds a custom AMI base for use by utilities and plain instances (and eventually soapbox). ECS doesn't allow ssh

- AMI includes teleport binaries and prep script to set local values

- Update Teleport to v3.0.1 and related configs

- Update Jenkins to allow access via Teleport