### PR TITLE
Address warning from newest AWS Provider

### DIFF
--- a/plain_instance/main.tf
+++ b/plain_instance/main.tf
@@ -128,7 +128,7 @@ EOF
 }
 
 resource "aws_kms_grant" "main" {
-  name              = "${env}-${application_name}-main"
+  name              = "${var.env}-${var.application_name}-main"
   key_id            = "${data.aws_kms_alias.main.target_key_arn}"
   grantee_principal = "${aws_iam_role.iam.arn}"
   operations        = ["Decrypt"]

--- a/plain_instance/main.tf
+++ b/plain_instance/main.tf
@@ -13,7 +13,7 @@ resource "aws_instance" "application" {
   ami           = "${data.aws_ami.base.id}"
   instance_type = "${var.instance_size}"
 
-  iam_instance_profile = "${aws_iam_instance_profile.iam}"
+  iam_instance_profile = "${aws_iam_instance_profile.iam.name}"
   user_data            = "${var.user_data}"
   key_name             = "${var.key_pair}"
 

--- a/test/all.tf
+++ b/test/all.tf
@@ -8,7 +8,7 @@ variable "region" {
 
 provider "aws" {
   region  = "${var.region}"
-  version = ">= 1.20.0"
+  version = "~> 1.42"
 }
 
 locals {

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -25,7 +25,7 @@ module "cert" {
 # Private DNS name inside VPC for auth nodes as light-weight service discovery
 resource "aws_route53_zone" "teleport" {
   name    = "teleport.local"
-  vpc     = "${data.aws_vpc.vpc.id}"
+  vpc     = ["${data.aws_vpc.vpc.id}"]
   comment = "${var.env} Teleport internal DNS"
 
   tags {

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -28,7 +28,7 @@ resource "aws_route53_zone" "teleport" {
   comment = "${var.env} Teleport internal DNS"
 
   vpc {
-    vpc_id = "${aws_vpc.primary.id}"
+    vpc_id = "${data.aws_vpc.vpc.id}"
   }
 
   tags {

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -25,7 +25,7 @@ module "cert" {
 # Private DNS name inside VPC for auth nodes as light-weight service discovery
 resource "aws_route53_zone" "teleport" {
   name    = "teleport.local"
-  vpc_id  = "${data.aws_vpc.vpc.id}"
+  vpc     = "${data.aws_vpc.vpc.id}"
   comment = "${var.env} Teleport internal DNS"
 
   tags {

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -25,8 +25,11 @@ module "cert" {
 # Private DNS name inside VPC for auth nodes as light-weight service discovery
 resource "aws_route53_zone" "teleport" {
   name    = "teleport.local"
-  vpc     = ["${data.aws_vpc.vpc.id}"]
   comment = "${var.env} Teleport internal DNS"
+
+  vpc {
+    vpc_id = "${aws_vpc.primary.id}"
+  }
 
   tags {
     env       = "${var.env}"

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -23,7 +23,7 @@ resource "aws_vpc" "primary" {
 
 resource "aws_route53_zone" "internal" {
   name    = "${var.env}.local"
-  vpc     = "${aws_vpc.primary.id}"
+  vpc     = ["${aws_vpc.primary.id}"]
   comment = "${var.env} internal DNS"
 
   tags {

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -23,7 +23,7 @@ resource "aws_vpc" "primary" {
 
 resource "aws_route53_zone" "internal" {
   name    = "${var.env}.local"
-  vpc_id  = "${aws_vpc.primary.id}"
+  vpc     = "${aws_vpc.primary.id}"
   comment = "${var.env} internal DNS"
 
   tags {

--- a/vpc/main.tf
+++ b/vpc/main.tf
@@ -23,8 +23,11 @@ resource "aws_vpc" "primary" {
 
 resource "aws_route53_zone" "internal" {
   name    = "${var.env}.local"
-  vpc     = ["${aws_vpc.primary.id}"]
   comment = "${var.env} internal DNS"
+
+  vpc {
+    vpc_id = "${aws_vpc.primary.id}"
+  }
 
   tags {
     env       = "${var.env}"


### PR DESCRIPTION
Resolves this warning from AWS Provider 1.42.0

```
Warning: module.utilities.module.teleport.aws_route53_zone.teleport: "vpc_id": [DEPRECATED] use 'vpc' attribute instead
```

And fixes the build for issues in the as yet unused `plain_instance` module.