### PR TITLE
Get Jenkins Production Ready

### DIFF
--- a/plain_instance/data.tf
+++ b/plain_instance/data.tf
@@ -14,10 +14,6 @@ data "aws_subnet" "application_subnet" {
   }
 }
 
-data "aws_secretsmanager_secret_version" "cluster_token" {
-  secret_id = "${var.env}/teleport/cluster_token"
-}
-
 data "aws_security_group" "ssh_proxies" {
   vpc_id = "${data.aws_vpc.vpc.id}"
 

--- a/utilities/jenkins/data.tf
+++ b/utilities/jenkins/data.tf
@@ -38,6 +38,26 @@ data "aws_secretsmanager_secret" "cluster_token" {
   name = "${var.env}/teleport/cluster_token"
 }
 
+data "aws_secretsmanager_secret_version" "github_client_id" {
+  secret_id = "${var.env}/jenkins/github_client_id"
+}
+
+data "aws_secretsmanager_secret_version" "github_client_secret" {
+  secret_id = "${var.env}/jenkins/github_client_secret"
+}
+
+data "aws_secretsmanager_secret_version" "github_password" {
+  secret_id = "${var.env}/jenkins/github_password"
+}
+
+data "aws_secretsmanager_secret_version" "slack_token" {
+  secret_id = "${var.env}/jenkins/slack_token"
+}
+
+data "aws_secretsmanager_secret_version" "docker_password" {
+  secret_id = "${var.env}/jenkins/docker_password"
+}
+
 data "aws_kms_alias" "main" {
   name = "alias/${var.env}-main"
 }

--- a/utilities/jenkins/data.tf
+++ b/utilities/jenkins/data.tf
@@ -34,6 +34,11 @@ data "aws_route53_zone" "internal" {
   private_zone = true
 }
 
+data "aws_acm_certificate" "wildcard" {
+  domain      = "${var.domain_name}"
+  most_recent = true
+}
+
 data "aws_secretsmanager_secret" "cluster_token" {
   name = "${var.env}/teleport/cluster_token"
 }

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -153,7 +153,7 @@ resource "aws_instance" "jenkins_primary" {
                 --name jenkins \
                 -p 8080:8080 \
                 -p 50000:50000 \
-                jskeets/jenkins-primary
+                adhocteam/jenkins
               EOF
 
   lifecycle {

--- a/utilities/jenkins/variables.tf
+++ b/utilities/jenkins/variables.tf
@@ -6,14 +6,36 @@ variable "domain_name" {
   description = "the external domain name for reaching the public resources. must have a certificate in ACM associated with it."
 }
 
-variable "num_workers" {
-  description = "How many worker nodes to create"
-  default     = 2
+variable "workers" {
+  description = "A list of maps describing workers. Lists are of the form: like { \"label\" = \"\", \"instance_type\"= \"\", \"number_of_executors\"= \"\"}"
+
+  default = [
+    {
+      "label"               = "general"
+      "instance_type"       = "t3.medium"
+      "number_of_executors" = "6"
+    },
+    {
+      "label"               = "general"
+      "instance_type"       = "t3.medium"
+      "number_of_executors" = "6"
+    },
+  ]
 }
 
-variable "num_executors" {
-  description = "How many execution slots per node"
-  default     = 4
+variable "github_user" {
+  description = "GitHub account to use for Jenkins admin features (e.g., setting up hooks) and posting messages"
+  default     = "jenkins-adhoc-team"
+}
+
+variable "docker_user" {
+  description = "Docker Hub account to use for publishing public images"
+  default     = "adhocjenkins"
+}
+
+variable "admin_team" {
+  description = "GitHub team to have admin access in the form: organization*team"
+  default     = "adhocteam*Infrastructure Team"
 }
 
 variable "jumpbox_sg" {
@@ -23,5 +45,10 @@ variable "jumpbox_sg" {
 
 variable "ssh_proxy_sg" {
   description = "OPTIONAL: the security group of the Teleport proxies"
+  default     = ""
+}
+
+variable "jenkins_url" {
+  description = "OPTIONAL: the URL at which jenkins will be served. Default is jenkins.{var.env}.{var.domain_name}"
   default     = ""
 }

--- a/utilities/jenkins/worker.tmpl
+++ b/utilities/jenkins/worker.tmpl
@@ -1,0 +1,33 @@
+#!usr/bin/env bash
+set -ex
+
+curl --create-dirs -sSLo /usr/share/jenkins/swarm-client.jar \
+    https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/3.14/swarm-client-3.14.jar
+
+chmod 755 /usr/share/jenkins
+
+yum install -y java-1.8.0-openjdk
+
+cat << EOF > /etc/systemd/system/jenkins_worker.service
+
+[Unit]
+Description=Jenkins swarm worker client application
+
+[Service]
+Type=simple
+User=ec2-user
+WorkingDirectory=/home/ec2-user
+ExecStart=/usr/bin/java -jar /usr/share/jenkins/swarm-client.jar \
+    -master ${master} \
+    -name "${labels}-${count}" \
+    -labels ${labels} \
+    -username ${username} \
+    -password ${password} \
+    -executors ${executors}
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable --now jenkins_worker

--- a/utilities/main.tf
+++ b/utilities/main.tf
@@ -20,4 +20,5 @@ module "jenkins" {
   domain_name  = "${var.domain_name}"
   jumpbox_sg   = "${module.jumpbox.security_group}"
   ssh_proxy_sg = "${module.teleport.security_group}"
+  workers      = "${var.jenkins_workers}"
 }

--- a/utilities/variables.tf
+++ b/utilities/variables.tf
@@ -10,3 +10,20 @@ variable "jumpbox_enabled" {
   description = "OPTIONAL: whether or not to enable the jumpbox"
   default     = "false"
 }
+
+variable "jenkins_workers" {
+  description = "A list of maps describing workers. Lists are of the form: like { \"label\" = \"\", \"instance_type\"= \"\", \"number_of_executors\"= \"\"}"
+
+  default = [
+    {
+      "label"               = "general"
+      "instance_type"       = "t3.medium"
+      "number_of_executors" = "6"
+    },
+    {
+      "label"               = "general"
+      "instance_type"       = "t3.medium"
+      "number_of_executors" = "6"
+    },
+  ]
+}


### PR DESCRIPTION
This PR addresses some remaining issues with Jenkins to get it fully "production" ready.

- Moves all secrets needed for Jenkins into AWS Secret Manager
- Allows for alternate Jenkins URLs (e.g., https://jenkins.adhoc.team)
- Templated worker nodes to allow for creating differently labeled and sized ones

The last point is the key here as it creates a nested list of maps to describe the desired worker nodes. I found this to be the best trade-off in how to match different labels, instance sizes, and number of executors to let us setup a `meatpillow` replacement that's beefy with few executors and a `website` replace that was smaller but with more executor slots.

An example input config looks like this:

https://github.com/adhocteam/tf/compare/bob/prod-ready?expand=1#diff-1512acd490377cdc3eac5b26dd132ed8R12

The code to process is for example here:

https://github.com/adhocteam/tf/compare/bob/prod-ready?expand=1#diff-e232c186527787bb3fb0e80c1fbceb18R295

I think in the end it's pretty straight forward. The main drawback is that we can't really validate the input so errors there are likely to throw odd terraform errors.

I tried a version via ansible but it basically ended up almost as complex since you needed to specify essentially all three pieces of information anyway to use the label as a Tag to allow terraform to target them correctly. The user data script wasn't so complex that I felt Ansible saved much there, so I opted for this version that keeps it all in Terraform and makes it fairly easy to add jenkins workers via Terraform config only.

