### PR TITLE
Get Jenkins production ready

### DIFF
--- a/plain_instance/data.tf
+++ b/plain_instance/data.tf
@@ -14,10 +14,6 @@ data "aws_subnet" "application_subnet" {
   }
 }
 
-data "aws_secretsmanager_secret_version" "cluster_token" {
-  secret_id = "${var.env}/teleport/cluster_token"
-}
-
 data "aws_security_group" "ssh_proxies" {
   vpc_id = "${data.aws_vpc.vpc.id}"
 

--- a/utilities/jenkins/README.md
+++ b/utilities/jenkins/README.md
@@ -14,3 +14,13 @@ Under user groups give the authenticated group permission you desire, at a minim
  Open blue ocean
  Add personal access token
  Select organization/repo
+
+## Redeploying
+
+To deploy an updated Jenkins primary node, e.g., after updating the Docker image to a new Jenkins version, use _taint_ in Terraform to mark it for redeployment.
+
+`terraform taint -module=utilities.jenkins aws_instance.jenkins_primary`
+
+then a subsequent `terraform apply` will pull down and deploy a new primary.
+
+**Note:** This process will incur a brief period of downtime.

--- a/utilities/jenkins/data.tf
+++ b/utilities/jenkins/data.tf
@@ -38,6 +38,26 @@ data "aws_secretsmanager_secret" "cluster_token" {
   name = "${var.env}/teleport/cluster_token"
 }
 
+data "aws_secretsmanager_secret_version" "github_client_id" {
+  secret_id = "${var.env}/jenkins/github_client_id"
+}
+
+data "aws_secretsmanager_secret_version" "github_client_secret" {
+  secret_id = "${var.env}/jenkins/github_client_secret"
+}
+
+data "aws_secretsmanager_secret_version" "github_password" {
+  secret_id = "${var.env}/jenkins/github_password"
+}
+
+data "aws_secretsmanager_secret_version" "slack_token" {
+  secret_id = "${var.env}/jenkins/slack_token"
+}
+
+data "aws_secretsmanager_secret_version" "docker_password" {
+  secret_id = "${var.env}/jenkins/docker_password"
+}
+
 data "aws_kms_alias" "main" {
   name = "alias/${var.env}-main"
 }

--- a/utilities/jenkins/data.tf
+++ b/utilities/jenkins/data.tf
@@ -34,6 +34,11 @@ data "aws_route53_zone" "internal" {
   private_zone = true
 }
 
+data "aws_acm_certificate" "wildcard" {
+  domain      = "${var.domain_name}"
+  most_recent = true
+}
+
 data "aws_secretsmanager_secret" "cluster_token" {
   name = "${var.env}/teleport/cluster_token"
 }

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -94,7 +94,7 @@ resource "aws_alb_listener" "https" {
   }
 }
 
-# Also allow it serve direct subdomains
+# Also allow it serve direct subdomains like jenkins.domain_name
 resource "aws_lb_listener_certificate" "domain_name" {
   listener_arn    = "${aws_lb_listener.https.arn}"
   certificate_arn = "${data.aws_acm_certificate.wildcard.arn}"
@@ -289,17 +289,17 @@ data "template_file" "jenkins_worker" {
   vars {
     count     = "${count.index}"
     master    = "http://${aws_route53_record.primary.fqdn}:8080"
-    labels    = "$lookup(element(var.workers, count.index), "label")"
+    labels    = "${lookup(element(var.workers, count.index), "label")}"
     username  = "${var.github_user}"
     password  = "${data.aws_secretsmanager_secret_version.github_password.secret_string}"
-    executors = "$lookup(element(var.workers, count.index), "number_of_executors")"
+    executors = "${lookup(element(var.workers, count.index), "number_of_executors")}"
   }
 }
 
 resource "aws_instance" "jenkins_worker" {
-  count                = "$length(var.workers)"
+  count                = "${length(var.workers)}"
   ami                  = "${data.aws_ami.base.id}"
-  instance_type        = "$lookup(element(var.workers, count.index), "instance_type")"
+  instance_type        = "${lookup(element(var.workers, count.index), "instance_type")}"
   key_name             = "infrastructure"
   iam_instance_profile = "${aws_iam_instance_profile.worker.name}"
 
@@ -312,7 +312,7 @@ resource "aws_instance" "jenkins_worker" {
     terraform = "true"
     Name      = "jenkins-worker-${count.index}"
     app       = "jenkins"
-    label     = "$lookup(element(var.workers, count.index), "label")"
+    label     = "${lookup(element(var.workers, count.index), "label")}"
     role      = "worker"
   }
 

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -153,7 +153,7 @@ resource "aws_instance" "jenkins_primary" {
                 --name jenkins \
                 -p 8080:8080 \
                 -p 50000:50000 \
-                jskeets/jenkins-primary
+                adhocteam/jenkins
               EOF
 
   lifecycle {

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -288,7 +288,7 @@ data "template_file" "jenkins_worker" {
   vars {
     count     = "${count.index}"
     master    = "http://${aws_route53_record.primary.fqdn}:8080"
-    labels    = "${element(split(",", element(var.workers, count.index)), 0)}"
+    label     = "${element(split(",", element(var.workers, count.index)), 0)}"
     username  = "${var.github_user}"
     password  = "${data.aws_secretsmanager_secret_version.github_password.secret_string}"
     executors = "${element(split(",", element(var.workers, count.index)), 2)}"

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -149,7 +149,7 @@ resource "aws_security_group_rule" "alb_egress" {
 
 resource "aws_instance" "jenkins_primary" {
   ami           = "${data.aws_ami.base.id}"
-  instance_type = "t2.micro"
+  instance_type = "t3.micro"
   key_name      = "infrastructure"
 
   associate_public_ip_address = false

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -5,7 +5,7 @@
 
 locals {
   default_url = "jenkins.${var.env}.${var.domain_name}"
-  url         = "$coalesce(var.jenkins_url, local.default_url}"
+  url         = "$coalesce(var.jenkins_url, local.default_url)"
 }
 
 resource "aws_alb" "jenkins" {

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -5,7 +5,7 @@
 
 locals {
   default_url = "jenkins.${var.env}.${var.domain_name}"
-  url         = "$coalesce(var.jenkins_url, local.default_url)"
+  url         = "${coalesce(var.jenkins_url, local.default_url)}"
 }
 
 resource "aws_alb" "jenkins" {

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -4,7 +4,7 @@
 #######
 
 locals {
-  default_url = "jenkins.${var.env}.${var.domain_name}"
+  default_url = "https://jenkins.${var.env}.${var.domain_name}"
   url         = "${coalesce(var.jenkins_url, local.default_url)}"
 }
 
@@ -167,14 +167,13 @@ resource "aws_instance" "jenkins_primary" {
                 -p 50000:50000 \
                 -e github_client_id="${data.aws_secretsmanager_secret_version.github_client_id.secret_string}" \
                 -e github_client_secret="${data.aws_secretsmanager_secret_version.github_client_secret.secret_string}" \
-                -e admin_team="${var.admin_team}" \
                 -e jenkins_url="${local.url}" \
                 -e github_user="${var.github_user}" \
                 -e github_password="${data.aws_secretsmanager_secret_version.github_password.secret_string}" \
                 -e docker_user="${var.docker_user}" \
                 -e docker_password="${data.aws_secretsmanager_secret_version.docker_password.secret_string}" \
                 -e slack_token="${data.aws_secretsmanager_secret_version.slack_token.secret_string}" \
-                adhocteam/jenkins
+                adhocteam/jenkins:latest
               EOF
 
   lifecycle {

--- a/utilities/jenkins/variables.tf
+++ b/utilities/jenkins/variables.tf
@@ -7,19 +7,11 @@ variable "domain_name" {
 }
 
 variable "workers" {
-  description = "A list of maps describing workers. Lists are of the form: like { \"label\" = \"\", \"instance_type\"= \"\", \"number_of_executors\"= \"\"}"
+  description = "A list of strings describing workers. Lists are of the form: label,instance_type,number_of_executors}"
 
   default = [
-    {
-      "label"               = "general"
-      "instance_type"       = "t3.medium"
-      "number_of_executors" = "6"
-    },
-    {
-      "label"               = "general"
-      "instance_type"       = "t3.medium"
-      "number_of_executors" = "6"
-    },
+    "general,t3.medium,6",
+    "general,t3.medium,6",
   ]
 }
 

--- a/utilities/jenkins/variables.tf
+++ b/utilities/jenkins/variables.tf
@@ -6,14 +6,36 @@ variable "domain_name" {
   description = "the external domain name for reaching the public resources. must have a certificate in ACM associated with it."
 }
 
-variable "num_workers" {
-  description = "How many worker nodes to create"
-  default     = 2
+variable "workers" {
+  description = "A list of maps describing workers. Lists are of the form: like { \"label\" = \"\", \"instance_type\"= \"\", \"number_of_executors\"= \"\"}"
+
+  default = [
+    {
+      "label"               = "general"
+      "instance_type"       = "t3.medium"
+      "number_of_executors" = "6"
+    },
+    {
+      "label"               = "general"
+      "instance_type"       = "t3.medium"
+      "number_of_executors" = "6"
+    },
+  ]
 }
 
-variable "num_executors" {
-  description = "How many execution slots per node"
-  default     = 4
+variable "github_user" {
+  description = "GitHub account to use for Jenkins admin features (e.g., setting up hooks) and posting messages"
+  default     = "jenkins-adhoc-team"
+}
+
+variable "docker_user" {
+  description = "Docker Hub account to use for publishing public images"
+  default     = "adhocjenkins"
+}
+
+variable "admin_team" {
+  description = "GitHub team to have admin access in the form: organization*team"
+  default     = "adhocteam*Infrastructure Team"
 }
 
 variable "jumpbox_sg" {
@@ -23,5 +45,10 @@ variable "jumpbox_sg" {
 
 variable "ssh_proxy_sg" {
   description = "OPTIONAL: the security group of the Teleport proxies"
+  default     = ""
+}
+
+variable "jenkins_url" {
+  description = "OPTIONAL: the URL at which jenkins will be served. Default is jenkins.{var.env}.{var.domain_name}"
   default     = ""
 }

--- a/utilities/jenkins/variables.tf
+++ b/utilities/jenkins/variables.tf
@@ -25,11 +25,6 @@ variable "docker_user" {
   default     = "adhocjenkins"
 }
 
-variable "admin_team" {
-  description = "GitHub team to have admin access in the form: organization*team"
-  default     = "adhocteam"
-}
-
 variable "jumpbox_sg" {
   description = "OPTIONAL: the security group of any jumpbox to provide SSH access"
   default     = ""

--- a/utilities/jenkins/variables.tf
+++ b/utilities/jenkins/variables.tf
@@ -27,7 +27,7 @@ variable "docker_user" {
 
 variable "admin_team" {
   description = "GitHub team to have admin access in the form: organization*team"
-  default     = "adhocteam*Infrastructure Team"
+  default     = "adhocteam"
 }
 
 variable "jumpbox_sg" {

--- a/utilities/jenkins/worker.tmpl
+++ b/utilities/jenkins/worker.tmpl
@@ -19,8 +19,8 @@ User=ec2-user
 WorkingDirectory=/home/ec2-user
 ExecStart=/usr/bin/java -jar /usr/share/jenkins/swarm-client.jar \
     -master ${master} \
-    -name "${labels}-${count}" \
-    -labels ${labels} \
+    -name "${label}-${count}" \
+    -labels ${label} worker \
     -username ${username} \
     -password ${password} \
     -executors ${executors}

--- a/utilities/jenkins/worker.tmpl
+++ b/utilities/jenkins/worker.tmpl
@@ -1,0 +1,33 @@
+#!usr/bin/env bash
+set -ex
+
+curl --create-dirs -sSLo /usr/share/jenkins/swarm-client.jar \
+    https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/3.14/swarm-client-3.14.jar
+
+chmod 755 /usr/share/jenkins
+
+yum install -y java-1.8.0-openjdk
+
+cat << EOF > /etc/systemd/system/jenkins_worker.service
+
+[Unit]
+Description=Jenkins swarm worker client application
+
+[Service]
+Type=simple
+User=ec2-user
+WorkingDirectory=/home/ec2-user
+ExecStart=/usr/bin/java -jar /usr/share/jenkins/swarm-client.jar \
+    -master ${master} \
+    -name "${labels}-${count}" \
+    -labels ${labels} \
+    -username ${username} \
+    -password ${password} \
+    -executors ${executors}
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl enable --now jenkins_worker

--- a/utilities/jenkins/worker.tmpl
+++ b/utilities/jenkins/worker.tmpl
@@ -4,6 +4,8 @@ set -ex
 curl --create-dirs -sSLo /usr/share/jenkins/swarm-client.jar \
     https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/3.14/swarm-client-3.14.jar
 
+echo "${label} worker" > /usr/share/jenkins/labels.txt
+
 chmod 755 /usr/share/jenkins
 
 yum install -y java-1.8.0-openjdk
@@ -20,7 +22,7 @@ WorkingDirectory=/home/ec2-user
 ExecStart=/usr/bin/java -jar /usr/share/jenkins/swarm-client.jar \
     -master ${master} \
     -name "${label}-${count}" \
-    -labels ${label} worker \
+    -labelsFile /usr/share/jenkins/labels.txt \
     -username ${username} \
     -password ${password} \
     -executors ${executors}

--- a/utilities/main.tf
+++ b/utilities/main.tf
@@ -20,4 +20,5 @@ module "jenkins" {
   domain_name  = "${var.domain_name}"
   jumpbox_sg   = "${module.jumpbox.security_group}"
   ssh_proxy_sg = "${module.teleport.security_group}"
+  workers      = "${var.jenkins_workers}"
 }

--- a/utilities/variables.tf
+++ b/utilities/variables.tf
@@ -10,3 +10,20 @@ variable "jumpbox_enabled" {
   description = "OPTIONAL: whether or not to enable the jumpbox"
   default     = "false"
 }
+
+variable "jenkins_workers" {
+  description = "A list of maps describing workers. Lists are of the form: like { \"label\" = \"\", \"instance_type\"= \"\", \"number_of_executors\"= \"\"}"
+
+  default = [
+    {
+      "label"               = "general"
+      "instance_type"       = "t3.medium"
+      "number_of_executors" = "6"
+    },
+    {
+      "label"               = "general"
+      "instance_type"       = "t3.medium"
+      "number_of_executors" = "6"
+    },
+  ]
+}

--- a/utilities/variables.tf
+++ b/utilities/variables.tf
@@ -12,18 +12,10 @@ variable "jumpbox_enabled" {
 }
 
 variable "jenkins_workers" {
-  description = "A list of maps describing workers. Lists are of the form: like { \"label\" = \"\", \"instance_type\"= \"\", \"number_of_executors\"= \"\"}"
+  description = "A list of strings describing workers. Lists are of the form: label,instance_type,number_of_executors}"
 
   default = [
-    {
-      "label"               = "general"
-      "instance_type"       = "t3.medium"
-      "number_of_executors" = "6"
-    },
-    {
-      "label"               = "general"
-      "instance_type"       = "t3.medium"
-      "number_of_executors" = "6"
-    },
+    "general,t3.medium,6",
+    "general,t3.medium,6",
   ]
 }


### PR DESCRIPTION
This PR addresses some remaining issues with Jenkins to get it fully "production" ready. This pairs with the Dockerized Jenkins primary at https://github.com/adhocteam/jenkins

- Moves all secrets needed for Jenkins into AWS Secret Manager
- Allows for alternate Jenkins URLs (e.g., https://jenkins.adhoc.team)
- Templated worker nodes to allow for creating differently labeled and sized ones

The last point is the key here as it creates a list of strings to describe the desired worker nodes. I found this to be the best trade-off in how to match different labels, instance sizes, and number of executors to let us setup a `meatpillow` replacement that's beefy with few executors and a `website` replace that was smaller but with more executor slots. Unfortunately, you can't use nested maps as most useful functions like `lookup` and `element` only work on "flat" maps/lists so I had to rely on strings as a de facto data structure 

An example input config looks like this:

https://github.com/adhocteam/tf/pull/20/commits/2d1ecdf3db4b332727d47ba171d4eb238a863fe6#diff-03dd2764f19a86446030b979e3844bcbR18

The code to process is, for example, like this here:

https://github.com/adhocteam/tf/pull/20/commits/2d1ecdf3db4b332727d47ba171d4eb238a863fe6#diff-e232c186527787bb3fb0e80c1fbceb18R292

The main drawback is that we can't really validate the input so errors there are likely to throw odd terraform errors. But I think in practice we can manage it well enough for our purposes.

I tried a version via ansible but it basically ended up almost as complex since you needed to specify essentially all three pieces of information anyway to use the label as a Tag to allow terraform to target them correctly. The user data script wasn't so complex that I felt Ansible saved much there, so I opted for this version that keeps it all in Terraform and makes it fairly easy to add jenkins workers via Terraform config only.

