### PR TITLE
Add module to run a Lambda function as a "cron" job

### DIFF
--- a/lambda_cron/data.tf
+++ b/lambda_cron/data.tf
@@ -1,0 +1,23 @@
+data "aws_s3_bucket" "releases" {
+  bucket = "${var.domain_name}-${var.env}-lambda-releases"
+}
+
+data "aws_vpc" "vpc" {
+  tags {
+    env = "${var.env}"
+  }
+}
+
+data "aws_subnet" "application_subnet" {
+  count  = 3
+  vpc_id = "${data.aws_vpc.vpc.id}"
+
+  tags {
+    name = "app-sub-${count.index}"
+    env  = "${var.env}"
+  }
+}
+
+data "aws_kms_alias" "main" {
+  name = "alias/${var.env}-main"
+}

--- a/lambda_cron/main.tf
+++ b/lambda_cron/main.tf
@@ -18,6 +18,10 @@ resource "aws_lambda_function" "job" {
 
   role = "${aws_iam_role.job.arn}"
 
+  environment {
+    variables = "${var.env_vars}"
+  }
+
   // Encrypts any environment variables
   kms_key_arn = "${data.aws_kms_alias.main.target_key_arn}"
 

--- a/lambda_cron/main.tf
+++ b/lambda_cron/main.tf
@@ -1,0 +1,176 @@
+locals {
+  handler = "${coalesce(var.handler, var.job_name)}"
+}
+
+resource "aws_lambda_function" "job" {
+  function_name = "${var.job_name}"
+  description   = "Terraform-managed cron job for ${var.job_name} that invokes ${local.handler}"
+
+  s3_bucket = "${data.aws_s3_bucket.releases.id}"
+  s3_key    = "${var.job_name}.zip"
+
+  handler = "${local.handler}"
+  runtime = "${var.runtime}"
+
+  // Allow to run up to 5 minutes. Max is 15 minutes
+  timeout     = 600
+  memory_size = "${var.memory_size}"
+
+  role = "${aws_iam_role.job.arn}"
+
+  // Encrypts any environment variables
+  kms_key_arn = "${data.aws_kms_alias.main.target_key_arn}"
+
+  vpc_config {
+    subnet_ids         = "${data.aws_subnet.application_subnet.*.id}"
+    security_group_ids = "[${aws_security_group.job.id}]"
+  }
+
+  tags {
+    terraform = "True"
+    app       = "${var.job_name}"
+    handler   = "${local.handler}"
+    type      = "cron"
+  }
+}
+
+#####
+# Default security group for lambda function
+#####
+resource "aws_security_group" "job" {
+  name_prefix = "${var.job_name}-"
+  vpc_id      = "${data.aws_vpc.vpc.id}"
+
+  tags {
+    env       = "${var.env}"
+    terraform = "True"
+    app       = "${var.job_name}"
+    name      = "cron-${var.job_name}"
+  }
+}
+
+// Block all inbound
+resource "aws_security_group_rule" "ingress" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 0
+  protocol  = -1
+  self      = true
+
+  security_group_id = "${aws_security_group.job.id}"
+}
+
+// Allow all outbound by default
+resource "aws_security_group_rule" "lb_egress" {
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = -1
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = "${aws_security_group.job.id}"
+}
+
+######
+# Cron job setup
+######
+resource "aws_cloudwatch_event_rule" "crontab" {
+  name                = "crontab-${var.env}-${var.job_name}"
+  description         = "Terraform-managed crontab for firing ${var.job_name}"
+  schedule_expression = "cron(${var.cron_expression})"
+}
+
+resource "aws_cloudwatch_event_target" "crontab" {
+  target_id = "propman_sync_lambda_target"
+  rule      = "${aws_cloudwatch_event_rule.job.name}"
+  arn       = "${aws_lambda_function.crontab.arn}"
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_crontab" {
+  statement_id  = "AllowExecutionFromCloudWatch"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.job.function_name}"
+  principal     = "events.amazonaws.com"
+  source_arn    = "${aws_cloudwatch_event_rule.crontab.arn}"
+}
+
+#####
+# IAM role which dictates what other AWS services the Lambda function
+# may access.
+#####
+
+resource "aws_iam_role" "job" {
+  name = "cronjob-${var.env}-${var.job_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+# Helper for allowing access to securely stored secrets
+# The helper uses the main shared key, provide your own by attaching to the output
+# role if you have a more restricted key used in Secrets Manager
+resource "aws_iam_role_policy_attachment" "basic-exec-role" {
+  role       = "${aws_iam_role.lambda_propman.name}"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+data "aws_iam_policy_document" "secrets" {
+  statement {
+    actions = [
+      "secretsmanager:GetSecretValue",
+    ]
+
+    resources = "${var.secrets}"
+  }
+}
+
+resource "aws_iam_policy" "secrets" {
+  name   = "${var.env}-${var.job_name}-secrets"
+  path   = "/${var.env}/${var.job_name}/"
+  policy = "${data.aws_iam_policy_document.secrets.json}"
+}
+
+resource "aws_iam_role_policy_attachment" "propman-access-serviceaccount" {
+  role       = "${aws_iam_role.lambda_propman.name}"
+  policy_arn = "${aws_iam_policy.propman-access-serviceaccount.arn}"
+}
+
+# Use of the shared KMS key for secrets decryption
+resource "aws_iam_policy" "shared_key_access" {
+  name        = "${var.env}-${var.job_name}-key-access"
+  path        = "/${var.env}/${var.job_name}/"
+  description = "Allows function to use main KMS key for environment"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "kms:Decrypt",
+            "Resource": "${data.aws_kms_alias.main.target_key_arn}"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_kms_grant" "primary" {
+  name              = "jenkins-primary-main"
+  key_id            = "${data.aws_kms_alias.main.target_key_arn}"
+  grantee_principal = "${aws_iam_role.primary.arn}"
+  operations        = ["Decrypt"]
+}

--- a/lambda_cron/main.tf
+++ b/lambda_cron/main.tf
@@ -26,8 +26,8 @@ resource "aws_lambda_function" "job" {
   kms_key_arn = "${data.aws_kms_alias.main.target_key_arn}"
 
   vpc_config {
-    subnet_ids         = "${data.aws_subnet.application_subnet.*.id}"
-    security_group_ids = "[${aws_security_group.job.id}]"
+    subnet_ids         = ["${data.aws_subnet.application_subnet.*.id}"]
+    security_group_ids = ["${aws_security_group.job.id}]"]
   }
 
   tags {

--- a/lambda_cron/main.tf
+++ b/lambda_cron/main.tf
@@ -126,8 +126,8 @@ EOF
 # Helper for allowing access to securely stored secrets
 # The helper uses the main shared key, provide your own by attaching to the output
 # role if you have a more restricted key used in Secrets Manager
-resource "aws_iam_role_policy_attachment" "basic-exec-role" {
-  role       = "${aws_iam_role.lambda_propman.name}"
+resource "aws_iam_role_policy_attachment" "basic_exec_role" {
+  role       = "${aws_iam_role.job.name}"
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
@@ -147,9 +147,9 @@ resource "aws_iam_policy" "secrets" {
   policy = "${data.aws_iam_policy_document.secrets.json}"
 }
 
-resource "aws_iam_role_policy_attachment" "propman-access-serviceaccount" {
-  role       = "${aws_iam_role.lambda_propman.name}"
-  policy_arn = "${aws_iam_policy.propman-access-serviceaccount.arn}"
+resource "aws_iam_role_policy_attachment" "secrets" {
+  role       = "${aws_iam_role.job.name}"
+  policy_arn = "${aws_iam_policy.secrets.arn}"
 }
 
 # Use of the shared KMS key for secrets decryption
@@ -172,8 +172,13 @@ resource "aws_iam_policy" "shared_key_access" {
 EOF
 }
 
+resource "aws_iam_role_policy_attachment" "shared_key_access" {
+  role       = "${aws_iam_role.job.name}"
+  policy_arn = "${aws_iam_policy.shared_key_access.arn}"
+}
+
 resource "aws_kms_grant" "primary" {
-  name              = "jenkins-primary-main"
+  name              = "${var.env}-cron-${var.job_name}"
   key_id            = "${data.aws_kms_alias.main.target_key_arn}"
   grantee_principal = "${aws_iam_role.primary.arn}"
   operations        = ["Decrypt"]

--- a/lambda_cron/main.tf
+++ b/lambda_cron/main.tf
@@ -86,8 +86,8 @@ resource "aws_cloudwatch_event_rule" "crontab" {
 
 resource "aws_cloudwatch_event_target" "crontab" {
   target_id = "propman_sync_lambda_target"
-  rule      = "${aws_cloudwatch_event_rule.job.name}"
-  arn       = "${aws_lambda_function.crontab.arn}"
+  rule      = "${aws_cloudwatch_event_rule.crontab.name}"
+  arn       = "${aws_lambda_function.job.arn}"
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_crontab" {
@@ -180,6 +180,6 @@ resource "aws_iam_role_policy_attachment" "shared_key_access" {
 resource "aws_kms_grant" "primary" {
   name              = "${var.env}-cron-${var.job_name}"
   key_id            = "${data.aws_kms_alias.main.target_key_arn}"
-  grantee_principal = "${aws_iam_role.primary.arn}"
+  grantee_principal = "${aws_iam_role.job.arn}"
   operations        = ["Decrypt"]
 }

--- a/lambda_cron/outputs.tf
+++ b/lambda_cron/outputs.tf
@@ -1,0 +1,4 @@
+output "job_iam_role" {
+  description = "IAM role name for attaching additional policies to the lambda function with aws_iam_role_policy_attachment"
+  value       = "${aws_iam_role.job.name}"
+}

--- a/lambda_cron/variables.tf
+++ b/lambda_cron/variables.tf
@@ -32,7 +32,7 @@ variable "memory_size" {
 variable "env_vars" {
   type        = "map"
   description = "OPTIONAL: a map of environment variables to set for the job"
-  default     = ""
+  default     = {}
 }
 
 variable "secrets" {

--- a/lambda_cron/variables.tf
+++ b/lambda_cron/variables.tf
@@ -1,0 +1,36 @@
+variable "env" {
+  description = "the name of the environment, e.g. \"testing\". it must be unique in the account."
+}
+
+variable "domain_name" {
+  description = "the external domain name for reaching the public resources. must have a certificate in ACM associated with it."
+}
+
+variable "job_name" {
+  description = "name of the application to be hosted. must be unique in the environment."
+}
+
+variable "cron_expression" {
+  description = "cron schedule expression. For example, \"0 12 * * ? *\" for daily at noon UTC. https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html#CronExpressions"
+}
+
+variable "runtime" {
+  description = "OPTIONAL: which lambda runtime to use to invoke the function. Defaults to Go 1.x"
+  default     = "go1.x"
+}
+
+variable "handler" {
+  description = "OPTIONAL: name of the handler for the lambda. Defaults to job_name"
+  default     = ""
+}
+
+variable "memory_size" {
+  description = "OPTIONAL: memory to allocate to the lambda function. Defaults to 1024mb"
+  default     = "1024"
+}
+
+variable "secrets" {
+  type        = "list"
+  description = "OPTIONAL: a list of ARNs for Secret Manager secrets to allow job to access"
+  default     = ""
+}

--- a/lambda_cron/variables.tf
+++ b/lambda_cron/variables.tf
@@ -38,5 +38,5 @@ variable "env_vars" {
 variable "secrets" {
   type        = "list"
   description = "OPTIONAL: a list of ARNs for Secret Manager secrets to allow job to access"
-  default     = ""
+  default     = []
 }

--- a/lambda_cron/variables.tf
+++ b/lambda_cron/variables.tf
@@ -7,7 +7,7 @@ variable "domain_name" {
 }
 
 variable "job_name" {
-  description = "name of the application to be hosted. must be unique in the environment."
+  description = "name of the job to be run. must be unique in the environment."
 }
 
 variable "cron_expression" {
@@ -27,6 +27,12 @@ variable "handler" {
 variable "memory_size" {
   description = "OPTIONAL: memory to allocate to the lambda function. Defaults to 1024mb"
   default     = "1024"
+}
+
+variable "env_vars" {
+  type        = "map"
+  description = "OPTIONAL: a map of environment variables to set for the job"
+  default     = ""
 }
 
 variable "secrets" {

--- a/main.tf
+++ b/main.tf
@@ -18,3 +18,19 @@ module "wildcard" {
   root_domain = "${var.domain_name}"
   domain      = "${var.domain_name}"
 }
+
+resource "aws_s3_bucket" "lambda_releases" {
+  bucket = "${var.domain_name}-${var.env}-lambda-releases"
+  acl    = "private"
+
+  versioning {
+    enabled = true
+  }
+
+  tags {
+    env         = "${var.env}"
+    domain_name = "${var.domain_name}"
+    terraform   = "True"
+    app         = "lambda-releases"
+  }
+}

--- a/test/all.tf
+++ b/test/all.tf
@@ -68,3 +68,22 @@ module "postgres" {
   app_sg           = "${module.demo.app_sg_id}"
   password         = "{$var.db_password}"
 }
+
+module "lambda_cron" {
+  source = "../lambda_cron"
+
+  env             = "${local.env}"
+  domain_name     = "${local.domain_name}"
+  job_name        = "crontab"
+  cron_expression = "* * ? * * *"
+
+  env_vars = {
+    "SOMETHING"      = "ANYTHING"
+    "SOMETHING_ELSE" = "NOTHING"
+  }
+
+  secrets = [
+    "arn:aws:secretsmanager:us-east-1:000000000000:secret:${local.env}/lambda/crontab/secret1",
+    "arn:aws:secretsmanager:us-east-1:000000000000:secret:${local.env}/lambda/crontab/secret2",
+  ]
+}


### PR DESCRIPTION
This module sets up a Lambda function to be run on a scheduled basis (a la cron)

- It adds a bucket to the base module to hold all the lambda function "releases"
- Sets up a lambda function that will load a zip from that bucket and execute it
- Allows for configuring the most important lambda variables (memory, handler function, environment variables, etc.)
- Takes in an AWS formatted cron schedule and sets up the scheduled event to trigger the lambda on schedule
- Provides built-in support for loading secrets from Secrets Manager, in line with our overall pattern

An example of using this module is in: https://github.com/adhocteam/tf/pull/21/files#diff-c5097e83574d5f8b73f95d764ade609fR72