### PR TITLE
Add preview site support for static sites

### DIFF
--- a/static_site/main.tf
+++ b/static_site/main.tf
@@ -127,7 +127,7 @@ resource "aws_route53_record" "preview" {
   type    = "CNAME"
   ttl     = "300"
 
-  records = ["${aws_s3_bucket.preview.website_domain_name}"]
+  records = ["${aws_s3_bucket.preview.website_domain}"]
 }
 
 # Create bucket to host the content

--- a/static_site/main.tf
+++ b/static_site/main.tf
@@ -127,7 +127,7 @@ resource "aws_route53_record" "preview" {
   type    = "CNAME"
   ttl     = "300"
 
-  records = ["${aws_s3_bucket.preview.bucket_domain_name}"]
+  records = ["${aws_s3_bucket.preview.website_domain_name}"]
 }
 
 # Create bucket to host the content


### PR DESCRIPTION
This adds preview site hosting to our static site module.

It'll tie into the default gatsby pipeline i'm setting up in https://github.com/adhocteam/jenkins-library to make that step simpler in the general case