### PR TITLE
Add pg_stat_statements to databases

### DIFF
--- a/database/main.tf
+++ b/database/main.tf
@@ -105,6 +105,16 @@ resource "aws_db_parameter_group" "postgres" {
     name  = "log_statement"
     value = "all"
   }
+
+  parameter {
+    name  = "shared_preload_libraries"
+    value = "pg_stat_statements"
+  }
+
+  parameter {
+    name  = "pg_stat_statements.track"
+    value = "ALL"
+  }
 }
 
 ####

--- a/database/main.tf
+++ b/database/main.tf
@@ -115,6 +115,11 @@ resource "aws_db_parameter_group" "postgres" {
     name  = "pg_stat_statements.track"
     value = "ALL"
   }
+
+  parameter {
+    name  = "track_activity_query_size"
+    value = "2048"
+  }
 }
 
 ####


### PR DESCRIPTION
Adds `pg_stat_statements` to our databases by default.

- See, for example, https://www.citusdata.com/blog/2019/02/08/the-most-useful-postgres-extension-pg-stat-statements/

- Enables use of tools like: https://github.com/ankane/pghero


