### PR TITLE
Fix preview site dns entry

### DIFF
--- a/static_site/main.tf
+++ b/static_site/main.tf
@@ -127,7 +127,7 @@ resource "aws_route53_record" "preview" {
   type    = "CNAME"
   ttl     = "300"
 
-  records = ["${aws_s3_bucket.preview.website_domain}"]
+  records = ["${aws_s3_bucket.preview.website_endpoint}"]
 }
 
 # Create bucket to host the content


### PR DESCRIPTION
# Fixes Broken Preview Links

See for example the link on: https://github.com/adhocteam/yubikey.adhoc.team/pull/8

### Description of the Change

- Switch from just the domain to the actual endpoint

### Acceptance criteria validation

- [X] Test case added that reproduces the bug
- [X] Test case now passes

Jenkins runs the test case and you can inspect the plan output to see the correct DNS entry now

### Verification Process

<!-- Provide any steps needed for a reviewer to verify that the bug is now fixed-->

### Requested feedback

<!-- What type of feedback would you like from reviewers? -->
