### PR TITLE
Fix preview site DNS entry

### DIFF
--- a/static_site/main.tf
+++ b/static_site/main.tf
@@ -127,7 +127,7 @@ resource "aws_route53_record" "preview" {
   type    = "CNAME"
   ttl     = "300"
 
-  records = ["${aws_s3_bucket.preview.website_domain}"]
+  records = ["${aws_s3_bucket.preview.website_endpoint}"]
 }
 
 # Create bucket to host the content


### PR DESCRIPTION
# Fixes Broken Preview Sites

The DNS for the preview sites currently just points right at S3 and not the bucket itself

`dig preview.yubikey.adhoc.team`:
```
;; ANSWER SECTION:
preview.yubikey.adhoc.team. 300 IN      CNAME   s3-website-us-east-1.amazonaws.com.
s3-website-us-east-1.amazonaws.com. 4 IN A      52.216.81.186
```

### Description of the Change

- Change the DNS entry to point to the bucket endpoint

### Acceptance criteria validation
- [x] DNS entry is now to the correct bucket

### Verification Process

In the `infrastructure` repo `terraform/shared` update `foundation.tf`:

1) Replace `?ref=0.1.4` with `?ref=fix-preview` for the Yubikey site
2) `terraform init --upgrade`
3) `terraform plan`
4) Confirm the DNS update is correct:
```
 ~ module.yubikey.aws_route53_record.preview
      records.1655427739: "" => "preview.yubikey.adhoc.team.s3-website-us-east-1.amazonaws.com"
      records.3440231085: "s3-website-us-east-1.amazonaws.com" => ""
```
5) Revert change to `foundation.tf`
