### PR TITLE
Increase size of Jenkins master volume

### DIFF
--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -176,6 +176,12 @@ resource "aws_instance" "jenkins_primary" {
                 adhocteam/jenkins:latest
               EOF
 
+  root_block_device {
+    volume_type           = "gp2"
+    volume_size           = 20
+    delete_on_termination = true
+  }
+
   lifecycle {
     ignore_changes = ["ami"]
   }

--- a/utilities/jenkins/worker.tmpl
+++ b/utilities/jenkins/worker.tmpl
@@ -4,7 +4,7 @@ set -ex
 export SWARM_CLIENT_VERSION=$(curl -s https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/maven-metadata.xml | awk -F'[<|>]' '/<latest>/ {print $3}')
 
 curl --create-dirs -sSLo /usr/share/jenkins/swarm-client.jar \
-    "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${SWARM_CLIENT_VERSION}/swarm-client-${SWARM_CLIENT_VERSION}.jar"
+    "https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/$SWARM_CLIENT_VERSION/swarm-client-$SWARM_CLIENT_VERSION.jar"
 
 echo "${label} worker" > /usr/share/jenkins/labels.txt
 


### PR DESCRIPTION
# Fixes Jenkins Primary volume too small

![image](https://user-images.githubusercontent.com/6646098/53385302-97918800-3943-11e9-85c6-b10135626b64.png)

### Description of the Change

- Increase size of Jenkins Primary hard drive from 8 to 20gb
- Fixed an issue with Terraform string interpolation messing with Bash string interpolation

Current Jenkins Primary drive is filling up: 
```
[ec2-user@ip-10-1-120-158 /]$ df
Filesystem     1K-blocks    Used Available Use% Mounted on
devtmpfs          984300       0    984300   0% /dev
tmpfs            1002228       0   1002228   0% /dev/shm
tmpfs            1002228     460   1001768   1% /run
tmpfs            1002228       0   1002228   0% /sys/fs/cgroup
/dev/nvme0n1p1   8376300 7929620    446680  95% /
tmpfs             200448       0    200448   0% /run/user/0
```

This change will increase the size of the drive on redeploy to provide more space.

### Acceptance criteria validation

- [x] More space available for Jenkins

### Verification Process

In the `infrastructure` repo `terraform/shared` update `foundation.tf`:

1) Replace `?ref=0.1.4` with `?ref=fix-jenkins-volume` for the Yubikey site
2) `terraform init --upgrade`
3) `terraform plan`
4) Confirm the drive is now larger :
```
-/+ module.utilities.module.jenkins.aws_instance.jenkins_primary (new resource required)
      ...
      root_block_device.#:                       "1" => "1"
      root_block_device.0.delete_on_termination: "true" => "true"
      root_block_device.0.volume_id:             "vol-0892800fe814fd030" => <computed>
      root_block_device.0.volume_size:           "8" => "20" (forces new resource)
      root_block_device.0.volume_type:           "gp2" => "gp2"
      ...
```
5) Revert change to `foundation.tf`

