### PR TITLE
Convert repo to work with Terraform 0.12

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
                 }
             }
             steps {
-                sh 'terraform fmt -check=true -diff=true'
+                sh 'terraform fmt -check=true -diff=true -recursive'
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
         stage('Terraform validation') {
             agent {
                 docker {
-                    image 'hashicorp/terraform:0.11.13'
+                    image 'hashicorp/terraform:0.12.1'
                     args '-w $WORKSPACE --entrypoint=""'
                 }
             }

--- a/app_base/data.tf
+++ b/app_base/data.tf
@@ -3,33 +3,33 @@
 #######
 
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
 data "aws_subnet" "application_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "app-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_subnet" "public_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "public-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_route53_zone" "external" {
-  name         = "${var.domain_name}"
+  name         = var.domain_name
   private_zone = false
 }
 
@@ -39,6 +39,7 @@ data "aws_route53_zone" "internal" {
 }
 
 data "aws_acm_certificate" "wildcard" {
-  domain      = "${var.domain_name}"
+  domain      = var.domain_name
   most_recent = true
 }
+

--- a/app_base/main.tf
+++ b/app_base/main.tf
@@ -3,21 +3,21 @@
 #######
 
 resource "aws_route53_record" "external_cname" {
-  zone_id = "${data.aws_route53_zone.external.id}"
-  name    = "${var.application_name}"
+  zone_id = data.aws_route53_zone.external.id
+  name    = var.application_name
   type    = "CNAME"
   ttl     = 30
 
-  records = ["${aws_alb.application_alb.dns_name}"]
+  records = [aws_alb.application_alb.dns_name]
 }
 
 resource "aws_route53_record" "internal_cname" {
-  zone_id = "${data.aws_route53_zone.internal.id}"
-  name    = "${var.application_name}"
+  zone_id = data.aws_route53_zone.internal.id
+  name    = var.application_name
   type    = "CNAME"
   ttl     = 30
 
-  records = ["${aws_alb.application_alb.dns_name}"]
+  records = [aws_alb.application_alb.dns_name]
 }
 
 #######
@@ -28,15 +28,15 @@ resource "aws_alb" "application_alb" {
   # max 6 characters for name prefix
   name_prefix     = "${format("%.5s", var.application_name)}-"
   internal        = false
-  security_groups = ["${aws_security_group.application_alb_sg.id}"]
-  subnets         = ["${data.aws_subnet.public_subnet.*.id}"]
+  security_groups = [aws_security_group.application_alb_sg.id]
+  subnets         = data.aws_subnet.public_subnet.*.id
 
   ip_address_type = "ipv4"
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
-    app       = "${var.application_name}"
+    app       = var.application_name
     name      = "alb-${var.application_name}"
   }
 }
@@ -45,38 +45,38 @@ resource "aws_alb" "application_alb" {
 resource "aws_alb_target_group" "application_target_group" {
   # max 6 characters for name prefix
   name_prefix = "${format("%.5s", var.application_name)}-"
-  port        = "${var.application_port}"
+  port        = var.application_port
   protocol    = "HTTP"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
-  target_type = "ip"                                       # Must use IP to support fargate
+  vpc_id      = data.aws_vpc.vpc.id
+  target_type = "ip" # Must use IP to support fargate
 
   health_check {
     interval            = 60
-    path                = "${var.health_check_path}"
-    port                = "${var.application_port}"
+    path                = var.health_check_path
+    port                = var.application_port
     healthy_threshold   = 2
     unhealthy_threshold = 2
   }
 
-  depends_on = ["aws_alb.application_alb"]
+  depends_on = [aws_alb.application_alb]
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
-    app       = "${var.application_name}"
+    app       = var.application_name
     name      = "alb-tg-${var.application_name}:${var.application_port}"
   }
 }
 
 resource "aws_alb_listener" "application_alb_https" {
-  load_balancer_arn = "${aws_alb.application_alb.arn}"
-  port              = "${var.loadbalancer_port}"
+  load_balancer_arn = aws_alb.application_alb.arn
+  port              = var.loadbalancer_port
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = "${data.aws_acm_certificate.wildcard.arn}"
+  certificate_arn   = data.aws_acm_certificate.wildcard.arn
 
   default_action {
-    target_group_arn = "${aws_alb_target_group.application_target_group.arn}"
+    target_group_arn = aws_alb_target_group.application_target_group.arn
     type             = "forward"
   }
 }
@@ -84,12 +84,12 @@ resource "aws_alb_listener" "application_alb_https" {
 # Security Group: world -> alb
 resource "aws_security_group" "application_alb_sg" {
   name_prefix = "${var.application_name}-alb-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
-    app       = "${var.application_name}"
+    app       = var.application_name
     name      = "world->alb-sg-${var.application_name}"
   }
 }
@@ -97,12 +97,12 @@ resource "aws_security_group" "application_alb_sg" {
 // Allow inbound only to our listening port
 resource "aws_security_group_rule" "lb_ingress" {
   type        = "ingress"
-  from_port   = "${var.loadbalancer_port}"
-  to_port     = "${var.loadbalancer_port}"
+  from_port   = var.loadbalancer_port
+  to_port     = var.loadbalancer_port
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.application_alb_sg.id}"
+  security_group_id = aws_security_group.application_alb_sg.id
 }
 
 // Allow all outbound by default
@@ -113,7 +113,7 @@ resource "aws_security_group_rule" "lb_egress" {
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.application_alb_sg.id}"
+  security_group_id = aws_security_group.application_alb_sg.id
 }
 
 #######
@@ -122,23 +122,23 @@ resource "aws_security_group_rule" "lb_egress" {
 
 resource "aws_security_group" "app_sg" {
   name_prefix = "${var.application_name}-app-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
 
-  tags {
-    app = "${var.application_name}"
-    env = "${var.env}"
+  tags = {
+    app = var.application_name
+    env = var.env
   }
 }
 
 // Allow inbound only to our application port
 resource "aws_security_group_rule" "app_ingress" {
   type                     = "ingress"
-  from_port                = "${var.application_port}"
-  to_port                  = "${var.application_port}"
+  from_port                = var.application_port
+  to_port                  = var.application_port
   protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.application_alb_sg.id}"
+  source_security_group_id = aws_security_group.application_alb_sg.id
 
-  security_group_id = "${aws_security_group.app_sg.id}"
+  security_group_id = aws_security_group.app_sg.id
 }
 
 // Allow all outbound, e.g. third-pary API endpoints, by default
@@ -149,5 +149,6 @@ resource "aws_security_group_rule" "app_egress" {
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.app_sg.id}"
+  security_group_id = aws_security_group.app_sg.id
 }
+

--- a/app_base/outputs.tf
+++ b/app_base/outputs.tf
@@ -1,7 +1,8 @@
 output "app_sg_id" {
-  value = "${aws_security_group.app_sg.id}"
+  value = aws_security_group.app_sg.id
 }
 
 output "lb_tg_arn" {
-  value = "${aws_alb_target_group.application_target_group.arn}"
+  value = aws_alb_target_group.application_target_group.arn
 }
+

--- a/app_base/variables.tf
+++ b/app_base/variables.tf
@@ -24,3 +24,4 @@ variable "loadbalancer_port" {
   description = "port on which the load balancer will be listening. it will terminate TLS on this port."
   default     = "443"
 }
+

--- a/app_base/versions.tf
+++ b/app_base/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/command_console/data.tf
+++ b/command_console/data.tf
@@ -1,36 +1,37 @@
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 data "aws_subnet" "application_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "app-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_security_group" "ssh_proxies" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env  = "${var.env}"
+  tags = {
+    env  = var.env
     app  = "teleport"
     Name = "teleport-proxies"
   }
 }
 
 data "aws_security_group" "jumpbox" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env  = "${var.env}"
+  tags = {
+    env  = var.env
     app  = "utilities"
     Name = "jumpbox"
   }
@@ -49,3 +50,4 @@ data "aws_ami" "base" {
     values = ["adhoc_base*"]
   }
 }
+

--- a/command_console/outputs.tf
+++ b/command_console/outputs.tf
@@ -1,8 +1,9 @@
 output "sg_id" {
-  value = "${aws_security_group.sg.id}"
+  value = aws_security_group.sg.id
 }
 
 output "instance_iam_role" {
   description = "IAM role name for attaching additional policies to the instance with aws_iam_role_policy_attachment"
-  value       = "${aws_iam_role.iam.name}"
+  value       = aws_iam_role.iam.name
 }
+

--- a/command_console/variables.tf
+++ b/command_console/variables.tf
@@ -16,3 +16,4 @@ variable "user_data" {
   description = "OPTIONAL: user data script to run on initialization"
   default     = ""
 }
+

--- a/command_console/versions.tf
+++ b/command_console/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/database/data.tf
+++ b/database/data.tf
@@ -8,31 +8,32 @@ data "aws_route53_zone" "internal" {
 }
 
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
 data "aws_subnet" "data_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "data-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_subnet" "application_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "app-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_kms_key" "main" {
   key_id = "alias/${var.env}-main"
 }
+

--- a/database/outputs.tf
+++ b/database/outputs.tf
@@ -1,8 +1,9 @@
 # The connection endpoint in address:port format
 output "url" {
-  value = "${aws_route53_record.rds_cname.fqdn}"
+  value = aws_route53_record.rds_cname.fqdn
 }
 
 output "security_group_id" {
-  value = "${aws_security_group.db_sg.id}"
+  value = aws_security_group.db_sg.id
 }
+

--- a/database/variables.tf
+++ b/database/variables.tf
@@ -15,4 +15,6 @@ variable "user" {
   default = "dbuser"
 }
 
-variable "password" {}
+variable "password" {
+}
+

--- a/database/versions.tf
+++ b/database/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/encryptkey/data.tf
+++ b/encryptkey/data.tf
@@ -1,1 +1,3 @@
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
+

--- a/encryptkey/main.tf
+++ b/encryptkey/main.tf
@@ -78,14 +78,16 @@ resource "aws_kms_key" "main" {
 }
 POLICY
 
-  tags {
-    env       = "${var.env}"
+
+  tags = {
+    env = var.env
     terraform = "true"
-    name      = "${var.env}-key-main"
+    name = "${var.env}-key-main"
   }
 }
 
 resource "aws_kms_alias" "main" {
-  name          = "alias/${var.env}-main"
-  target_key_id = "${aws_kms_key.main.key_id}"
+  name = "alias/${var.env}-main"
+  target_key_id = aws_kms_key.main.key_id
 }
+

--- a/encryptkey/outputs.tf
+++ b/encryptkey/outputs.tf
@@ -1,3 +1,4 @@
 output "key_arn" {
-  value = "${aws_kms_key.main.arn}"
+  value = aws_kms_key.main.arn
 }
+

--- a/encryptkey/variables.tf
+++ b/encryptkey/variables.tf
@@ -1,3 +1,4 @@
 variable "env" {
   description = "the name of the environment, e.g. \"testing\". it must be unique in the account."
 }
+

--- a/encryptkey/versions.tf
+++ b/encryptkey/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/fargate_cluster/data.tf
+++ b/fargate_cluster/data.tf
@@ -1,17 +1,19 @@
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
 
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
 data "aws_subnet" "application_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "app-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
+

--- a/fargate_cluster/main.tf
+++ b/fargate_cluster/main.tf
@@ -51,15 +51,7 @@ resource "aws_ecs_service" "application" {
   desired_count   = 2
 
   network_configuration {
-    subnets = data.aws_subnet.application_subnet.*.id
-    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-    # force an interpolation expression to be interpreted as a list by wrapping it
-    # in an extra set of list brackets. That form was supported for compatibilty in
-    # v0.11, but is no longer supported in Terraform v0.12.
-    #
-    # If the expression in the following list itself returns a list, remove the
-    # brackets to avoid interpretation as a list of lists. If the expression
-    # returns a single list item then leave it as-is and remove this TODO comment.
+    subnets         = data.aws_subnet.application_subnet.*.id
     security_groups = [module.fargate_base.app_sg_id]
   }
 

--- a/fargate_cluster/main.tf
+++ b/fargate_cluster/main.tf
@@ -1,12 +1,12 @@
 module "fargate_base" {
   source = "../app_base"
 
-  env               = "${var.env}"
-  domain_name       = "${var.domain_name}"
-  application_name  = "${var.application_name}"
-  application_port  = "${var.application_port}"
-  loadbalancer_port = "${var.loadbalancer_port}"
-  health_check_path = "${var.health_check_path}"
+  env               = var.env
+  domain_name       = var.domain_name
+  application_name  = var.application_name
+  application_port  = var.application_port
+  loadbalancer_port = var.loadbalancer_port
+  health_check_path = var.health_check_path
 }
 
 # TODO(bob) May need a call to create a service linked role first:
@@ -14,81 +14,78 @@ module "fargate_base" {
 # seems to be one-time only thing so maybe bootbox?
 
 resource "aws_ecs_cluster" "app" {
-  name = "${var.application_name}"
+  name = var.application_name
 }
 
 # Must use template here to get ports as ints
 data "template_file" "task" {
-  template = "${file("${path.module}/container_task.tmpl")}"
+  template = file("${path.module}/container_task.tmpl")
 
-  vars {
-    image                 = "${var.docker_image}"
-    awslogs-group         = "${aws_cloudwatch_log_group.app.name}"
-    awslogs-region        = "${data.aws_region.current.name}"
+  vars = {
+    image                 = var.docker_image
+    awslogs-group         = aws_cloudwatch_log_group.app.name
+    awslogs-region        = data.aws_region.current.name
     awslogs-stream-prefix = "${var.env}-${var.application_name}"
-    name                  = "${var.application_name}"
-    port                  = "${var.application_port}"
-    environment_variables = "${jsonencode(var.environment_variables)}"
+    name                  = var.application_name
+    port                  = var.application_port
+    environment_variables = jsonencode(var.environment_variables)
   }
 }
 
 resource "aws_ecs_task_definition" "app" {
   family                = "${var.env}-${var.application_name}"
-  container_definitions = "${data.template_file.task.rendered}"
-  execution_role_arn    = "${aws_iam_role.ecs_execution.arn}"
+  container_definitions = data.template_file.task.rendered
+  execution_role_arn    = aws_iam_role.ecs_execution.arn
 
   requires_compatibilities = ["FARGATE"]
   network_mode             = "awsvpc"
-  cpu                      = "2048"      # 2 vCPU
-  memory                   = "4096"      # 4 GiB
+  cpu                      = "2048" # 2 vCPU
+  memory                   = "4096" # 4 GiB
 }
 
 resource "aws_ecs_service" "application" {
-  name            = "${var.application_name}"
-  cluster         = "${aws_ecs_cluster.app.id}"
-  task_definition = "${aws_ecs_task_definition.app.arn}"
+  name            = var.application_name
+  cluster         = aws_ecs_cluster.app.id
+  task_definition = aws_ecs_task_definition.app.arn
   launch_type     = "FARGATE"
   desired_count   = 2
 
   network_configuration {
-    subnets         = ["${data.aws_subnet.application_subnet.*.id}"]
-    security_groups = ["${module.fargate_base.app_sg_id}"]
+    subnets = data.aws_subnet.application_subnet.*.id
+    # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+    # force an interpolation expression to be interpreted as a list by wrapping it
+    # in an extra set of list brackets. That form was supported for compatibilty in
+    # v0.11, but is no longer supported in Terraform v0.12.
+    #
+    # If the expression in the following list itself returns a list, remove the
+    # brackets to avoid interpretation as a list of lists. If the expression
+    # returns a single list item then leave it as-is and remove this TODO comment.
+    security_groups = [module.fargate_base.app_sg_id]
   }
 
   load_balancer {
-    target_group_arn = "${module.fargate_base.lb_tg_arn}"
-    container_name   = "${var.application_name}"
-    container_port   = "${var.application_port}"
+    target_group_arn = module.fargate_base.lb_tg_arn
+    container_name   = var.application_name
+    container_port   = var.application_port
   }
 
   depends_on = [
-    # https://www.terraform.io/docs/providers/aws/r/ecs_service.html
-    # Note: To prevent a race condition during service deletion,
-    # make sure to set depends_on to the related aws_iam_role_policy;
-    # otherwise, the policy may be destroyed too soon and
-    # the ECS service will then get stuck in the DRAINING state.
-    "aws_iam_role_policy.ecs_execution",
-
-    # This prevents errors with the load balancer targeting group
-    # not being linked yet causing invalid parameter errors
-    "module.fargate_base",
+    aws_iam_role_policy.ecs_execution,
+    module.fargate_base,
   ]
 
   lifecycle {
-    ignore_changes = [
-      # Ignore changes to the desired count (which may be due to autoscaling)
-      "desired_count",
-    ]
+    ignore_changes = [desired_count]
   }
 }
 
 resource "aws_cloudwatch_log_group" "app" {
   name = "${var.env}-${var.application_name}"
 
-  tags {
+  tags = {
     Name        = "${var.env}-${var.application_name}"
-    environment = "${var.env}"
-    app         = "${var.application_name}"
+    environment = var.env
+    app         = var.application_name
   }
 }
 
@@ -109,11 +106,12 @@ resource "aws_iam_role" "ecs_execution" {
   ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy" "ecs_execution" {
   name = "${var.env}-${var.application_name}-ecs_execution"
-  role = "${aws_iam_role.ecs_execution.id}"
+  role = aws_iam_role.ecs_execution.id
 
   policy = <<EOF
 {
@@ -135,6 +133,7 @@ resource "aws_iam_role_policy" "ecs_execution" {
   ]
 }
 EOF
+
 }
 
 ######
@@ -142,152 +141,153 @@ EOF
 ######
 
 resource "aws_appautoscaling_target" "service" {
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_cluster.app.name}/${aws_ecs_service.application.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
-  max_capacity       = 8
-  min_capacity       = 2
+service_namespace  = "ecs"
+resource_id        = "service/${aws_ecs_cluster.app.name}/${aws_ecs_service.application.name}"
+scalable_dimension = "ecs:service:DesiredCount"
+max_capacity       = 8
+min_capacity       = 2
 }
 
 # Alarms to trigger actions
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_high" {
-  alarm_name          = "${var.env}-${var.application_name}-CPU-Utilization-High"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "2"
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/ECS"
-  period              = "300"
-  statistic           = "Maximum"
-  threshold           = 80
+alarm_name          = "${var.env}-${var.application_name}-CPU-Utilization-High"
+comparison_operator = "GreaterThanOrEqualToThreshold"
+evaluation_periods  = "2"
+metric_name         = "CPUUtilization"
+namespace           = "AWS/ECS"
+period              = "300"
+statistic           = "Maximum"
+threshold           = 80
 
-  dimensions {
-    ClusterName = "${aws_ecs_cluster.app.name}"
-    ServiceName = "${aws_ecs_service.application.name}"
-  }
+dimensions = {
+ClusterName = aws_ecs_cluster.app.name
+ServiceName = aws_ecs_service.application.name
+}
 
-  alarm_description = "Scale up if maximum CPU Utilization is above 80% for two consecutive 5 minute periods"
-  alarm_actions     = ["${aws_appautoscaling_policy.up.arn}"]
+alarm_description = "Scale up if maximum CPU Utilization is above 80% for two consecutive 5 minute periods"
+alarm_actions     = [aws_appautoscaling_policy.up.arn]
 
-  lifecycle {
-    create_before_destroy = true
-  }
+lifecycle {
+create_before_destroy = true
+}
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_utilization_high" {
-  alarm_name          = "${var.env}-${var.application_name}-Memory-Utilization-High"
-  comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "3"
-  metric_name         = "MemoryUtilization"
-  namespace           = "AWS/ECS"
-  period              = "300"
-  statistic           = "Maximum"
-  threshold           = 90
+alarm_name          = "${var.env}-${var.application_name}-Memory-Utilization-High"
+comparison_operator = "GreaterThanOrEqualToThreshold"
+evaluation_periods  = "3"
+metric_name         = "MemoryUtilization"
+namespace           = "AWS/ECS"
+period              = "300"
+statistic           = "Maximum"
+threshold           = 90
 
-  dimensions {
-    ClusterName = "${aws_ecs_cluster.app.name}"
-    ServiceName = "${aws_ecs_service.application.name}"
-  }
+dimensions = {
+ClusterName = aws_ecs_cluster.app.name
+ServiceName = aws_ecs_service.application.name
+}
 
-  alarm_description = "Scale up if maximum Memory Reservation is above 90% for two consecutive 5 minute periods"
-  alarm_actions     = ["${aws_appautoscaling_policy.up.arn}"]
+alarm_description = "Scale up if maximum Memory Reservation is above 90% for two consecutive 5 minute periods"
+alarm_actions     = [aws_appautoscaling_policy.up.arn]
 
-  lifecycle {
-    create_before_destroy = true
-  }
+lifecycle {
+create_before_destroy = true
+}
 
-  # This is required to make cloudwatch alarms creation sequential, AWS doesn't
-  # support modifying alarms concurrently.
-  depends_on = ["aws_cloudwatch_metric_alarm.cpu_utilization_high"]
+# This is required to make cloudwatch alarms creation sequential, AWS doesn't
+# support modifying alarms concurrently.
+depends_on = [aws_cloudwatch_metric_alarm.cpu_utilization_high]
 }
 
 resource "aws_cloudwatch_metric_alarm" "cpu_utilization_low" {
-  alarm_name          = "${var.env}-${var.application_name}-CPU-Utilization-Low"
-  comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "CPUUtilization"
-  namespace           = "AWS/ECS"
-  period              = "300"
-  statistic           = "Average"
-  threshold           = 20
+alarm_name          = "${var.env}-${var.application_name}-CPU-Utilization-Low"
+comparison_operator = "LessThanThreshold"
+evaluation_periods  = "1"
+metric_name         = "CPUUtilization"
+namespace           = "AWS/ECS"
+period              = "300"
+statistic           = "Average"
+threshold           = 20
 
-  dimensions {
-    ClusterName = "${aws_ecs_cluster.app.name}"
-    ServiceName = "${aws_ecs_service.application.name}"
-  }
+dimensions = {
+ClusterName = aws_ecs_cluster.app.name
+ServiceName = aws_ecs_service.application.name
+}
 
-  alarm_description = "Scale down if the CPU Utilitization is below 20% for 5 minutes"
-  alarm_actions     = ["${aws_appautoscaling_policy.down.arn}"]
+alarm_description = "Scale down if the CPU Utilitization is below 20% for 5 minutes"
+alarm_actions     = [aws_appautoscaling_policy.down.arn]
 
-  lifecycle {
-    create_before_destroy = true
-  }
+lifecycle {
+create_before_destroy = true
+}
 
-  # This is required to make cloudwatch alarms creation sequential, AWS doesn't
-  # support modifying alarms concurrently.
-  depends_on = ["aws_cloudwatch_metric_alarm.memory_utilization_high"]
+# This is required to make cloudwatch alarms creation sequential, AWS doesn't
+# support modifying alarms concurrently.
+depends_on = [aws_cloudwatch_metric_alarm.memory_utilization_high]
 }
 
 resource "aws_cloudwatch_metric_alarm" "memory_utilization_low" {
-  alarm_name          = "${var.env}-${var.application_name}-Memory-Utilization-Low"
-  comparison_operator = "LessThanThreshold"
-  evaluation_periods  = "1"
-  metric_name         = "MemoryUtilization"
-  namespace           = "AWS/ECS"
-  period              = "300"
-  statistic           = "Average"
-  threshold           = 20
+alarm_name          = "${var.env}-${var.application_name}-Memory-Utilization-Low"
+comparison_operator = "LessThanThreshold"
+evaluation_periods  = "1"
+metric_name         = "MemoryUtilization"
+namespace           = "AWS/ECS"
+period              = "300"
+statistic           = "Average"
+threshold           = 20
 
-  dimensions {
-    ClusterName = "${aws_ecs_cluster.app.name}"
-    ServiceName = "${aws_ecs_service.application.name}"
-  }
+dimensions = {
+ClusterName = aws_ecs_cluster.app.name
+ServiceName = aws_ecs_service.application.name
+}
 
-  alarm_description = "Scale down if the Memory Usage is below 20% for 5 minutes"
-  alarm_actions     = ["${aws_appautoscaling_policy.down.arn}"]
+alarm_description = "Scale down if the Memory Usage is below 20% for 5 minutes"
+alarm_actions     = [aws_appautoscaling_policy.down.arn]
 
-  lifecycle {
-    create_before_destroy = true
-  }
+lifecycle {
+create_before_destroy = true
+}
 
-  # This is required to make cloudwatch alarms creation sequential, AWS doesn't
-  # support modifying alarms concurrently.
-  depends_on = ["aws_cloudwatch_metric_alarm.cpu_utilization_low"]
+# This is required to make cloudwatch alarms creation sequential, AWS doesn't
+# support modifying alarms concurrently.
+depends_on = [aws_cloudwatch_metric_alarm.cpu_utilization_low]
 }
 
 # Autoscaling actions
 resource "aws_appautoscaling_policy" "up" {
-  name               = "app-scale-up"
-  service_namespace  = "${aws_appautoscaling_target.service.service_namespace}"
-  resource_id        = "${aws_appautoscaling_target.service.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.service.scalable_dimension}"
+name               = "app-scale-up"
+service_namespace  = aws_appautoscaling_target.service.service_namespace
+resource_id        = aws_appautoscaling_target.service.resource_id
+scalable_dimension = aws_appautoscaling_target.service.scalable_dimension
 
-  step_scaling_policy_configuration {
-    adjustment_type         = "ChangeInCapacity"
-    cooldown                = 60
-    metric_aggregation_type = "Average"
+step_scaling_policy_configuration {
+adjustment_type         = "ChangeInCapacity"
+cooldown                = 60
+metric_aggregation_type = "Average"
 
-    step_adjustment {
-      metric_interval_lower_bound = 0
-      scaling_adjustment          = 1
-    }
-  }
+step_adjustment {
+metric_interval_lower_bound = 0
+scaling_adjustment          = 1
+}
+}
 }
 
 resource "aws_appautoscaling_policy" "down" {
-  name               = "app-scale-down"
-  service_namespace  = "${aws_appautoscaling_target.service.service_namespace}"
-  resource_id        = "${aws_appautoscaling_target.service.resource_id}"
-  scalable_dimension = "${aws_appautoscaling_target.service.scalable_dimension}"
+name               = "app-scale-down"
+service_namespace  = aws_appautoscaling_target.service.service_namespace
+resource_id        = aws_appautoscaling_target.service.resource_id
+scalable_dimension = aws_appautoscaling_target.service.scalable_dimension
 
-  step_scaling_policy_configuration {
-    adjustment_type         = "ChangeInCapacity"
-    cooldown                = 300
-    metric_aggregation_type = "Average"
+step_scaling_policy_configuration {
+adjustment_type         = "ChangeInCapacity"
+cooldown                = 300
+metric_aggregation_type = "Average"
 
-    step_adjustment {
-      metric_interval_upper_bound = 0
-      scaling_adjustment          = -1
-    }
-  }
+step_adjustment {
+metric_interval_upper_bound = 0
+scaling_adjustment          = -1
 }
+}
+}
+

--- a/fargate_cluster/outputs.tf
+++ b/fargate_cluster/outputs.tf
@@ -1,3 +1,4 @@
 output "app_sg_id" {
-  value = "${module.fargate_base.app_sg_id}"
+  value = module.fargate_base.app_sg_id
 }
+

--- a/fargate_cluster/variables.tf
+++ b/fargate_cluster/variables.tf
@@ -25,7 +25,7 @@ variable "loadbalancer_port" {
 }
 
 variable "environment_variables" {
-  type        = "list"
+  type        = list(string)
   description = "environment variables to inject into the docker containers. a list of maps."
   default     = []
 }
@@ -42,4 +42,3 @@ variable "health_check_path" {
 #   description = "list of stored secrets to inject into the docker container. a list of maps."
 #   default     = []
 # }
-

--- a/fargate_cluster/versions.tf
+++ b/fargate_cluster/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/ingress/data.tf
+++ b/ingress/data.tf
@@ -1,36 +1,37 @@
 #######
 ### Lookup resources already created by foundation
 #######
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
 data "aws_subnet" "application" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "app-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_subnet" "public" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "public-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_route53_zone" "external" {
-  name         = "${var.domain_name}"
+  name         = var.domain_name
   private_zone = false
 }
 
@@ -40,7 +41,7 @@ data "aws_route53_zone" "internal" {
 }
 
 data "aws_acm_certificate" "wildcard" {
-  domain      = "${var.domain_name}"
+  domain      = var.domain_name
   most_recent = true
 }
 
@@ -49,10 +50,10 @@ data "aws_kms_alias" "main" {
 }
 
 data "aws_security_group" "jumpbox" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env  = "${var.env}"
+  tags = {
+    env  = var.env
     app  = "utilities"
     Name = "jumpbox"
   }
@@ -67,3 +68,4 @@ data "aws_ami" "base" {
     values = ["adhoc_base*"]
   }
 }
+

--- a/ingress/main.tf
+++ b/ingress/main.tf
@@ -7,12 +7,12 @@ resource "aws_lb" "nlb" {
   name_prefix        = "in-nlb"
   internal           = false
   load_balancer_type = "network"
-  subnets            = ["${data.aws_subnet.public.*.id}"]
+  subnets            = data.aws_subnet.public.*.id
 
   enable_cross_zone_load_balancing = true
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "ingress"
     Name      = "ingress-nlb"
@@ -20,13 +20,13 @@ resource "aws_lb" "nlb" {
 }
 
 resource "aws_lb_listener" "http" {
-  load_balancer_arn = "${aws_lb.nlb.arn}"
+  load_balancer_arn = aws_lb.nlb.arn
   port              = "80"
   protocol          = "TCP"
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.http.arn}"
+    target_group_arn = aws_lb_target_group.http.arn
   }
 }
 
@@ -34,17 +34,17 @@ resource "aws_lb_target_group" "http" {
   name_prefix = "inhttp"
   port        = "80"
   protocol    = "TCP"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
 
   target_type = "ip"
 
-  health_check = {
+  health_check {
     protocol = "TCP"
     port     = 200
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "ingress"
     Name      = "ingress-nlb-http"
@@ -53,16 +53,16 @@ resource "aws_lb_target_group" "http" {
 
 # TODO
 resource "aws_lb_listener" "https" {
-  load_balancer_arn = "${aws_lb.nlb.arn}"
+  load_balancer_arn = aws_lb.nlb.arn
   port              = "443"
   protocol          = "TLS"
 
   ssl_policy      = "ELBSecurityPolicy-FS-2018-06"
-  certificate_arn = "${data.aws_acm_certificate.wildcard.arn}"
+  certificate_arn = data.aws_acm_certificate.wildcard.arn
 
   default_action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.https.arn}"
+    target_group_arn = aws_lb_target_group.https.arn
   }
 }
 
@@ -70,7 +70,7 @@ resource "aws_lb_target_group" "https" {
   name_prefix = "in-tls"
   port        = "443"
   protocol    = "TLS"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
 
   # Use IP to support Fargate clusters
   target_type = "ip"
@@ -78,13 +78,13 @@ resource "aws_lb_target_group" "https" {
   # Enable proxy protocol to get original source IP
   proxy_protocol_v2 = true
 
-  health_check = {
+  health_check {
     protocol = "TCP"
     port     = 200
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "ingress"
     Name      = "ingress-nlb-https"
@@ -93,14 +93,14 @@ resource "aws_lb_target_group" "https" {
 
 resource "aws_alb_target_group_attachment" "http" {
   count            = 1
-  target_group_arn = "${aws_lb_target_group.http.arn}"
-  target_id        = "${element(aws_instance.nginx.*.private_ip, count.index)}"
+  target_group_arn = aws_lb_target_group.http.arn
+  target_id        = element(aws_instance.nginx.*.private_ip, count.index)
 }
 
 resource "aws_alb_target_group_attachment" "https" {
   count            = 1
-  target_group_arn = "${aws_lb_target_group.https.arn}"
-  target_id        = "${element(aws_instance.nginx.*.private_ip, count.index)}"
+  target_group_arn = aws_lb_target_group.https.arn
+  target_id        = element(aws_instance.nginx.*.private_ip, count.index)
 }
 
 #######
@@ -113,8 +113,8 @@ resource "aws_ecr_repository" "nginx" {
 }
 
 resource "aws_ecr_repository_policy" "cross_account_access" {
-  count      = "${length(var.other_accounts)}"
-  repository = "${aws_ecr_repository.nginx.name}"
+  count      = length(var.other_accounts)
+  repository = aws_ecr_repository.nginx.name
 
   policy = <<EOF
 {
@@ -140,6 +140,7 @@ resource "aws_ecr_repository_policy" "cross_account_access" {
   ]
 }
 EOF
+
 }
 
 data "aws_iam_policy_document" "cross_account_assume_role" {
@@ -147,8 +148,8 @@ data "aws_iam_policy_document" "cross_account_assume_role" {
     effect = "Allow"
 
     principals {
-      type        = "AWS"
-      identifiers = ["${var.other_accounts}"]
+      type = "AWS"
+      identifiers = var.other_accounts
     }
 
     actions = ["sts:AssumeRole"]
@@ -156,21 +157,21 @@ data "aws_iam_policy_document" "cross_account_assume_role" {
 }
 
 resource "aws_iam_role" "cross_account_assume_role" {
-  name               = "ingress-cross-account-${var.env}"
-  assume_role_policy = "${data.aws_iam_policy_document.cross_account_assume_role.json}"
+  name = "ingress-cross-account-${var.env}"
+  assume_role_policy = data.aws_iam_policy_document.cross_account_assume_role.json
 }
 
 resource "aws_iam_role_policy_attachment" "cross_account_assume_role" {
-  role       = "${aws_iam_role.cross_account_assume_role.name}"
+  role = aws_iam_role.cross_account_assume_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
 }
 
 resource "aws_instance" "nginx" {
-  count         = 1
-  ami           = "${data.aws_ami.base.id}"
+  count = 1
+  ami = data.aws_ami.base.id
   instance_type = "t3.medium"
 
-  iam_instance_profile = "${aws_iam_instance_profile.iam.name}"
+  iam_instance_profile = aws_iam_instance_profile.iam.name
 
   user_data = <<EOF
 #!/usr/bin/env bash
@@ -187,104 +188,105 @@ docker run -d --restart=unless-stopped \
   ${aws_ecr_repository.nginx.repository_url}:latest
 EOF
 
-  key_name = "infrastructure"
 
-  associate_public_ip_address = false
+key_name = "infrastructure"
 
-  #distribute instances across AZs
-  subnet_id              = "${element(data.aws_subnet.application.*.id,count.index)}"
-  vpc_security_group_ids = ["${aws_security_group.nginx.id}"]
+associate_public_ip_address = false
 
-  lifecycle {
-    ignore_changes = ["ami"]
-  }
+#distribute instances across AZs
+subnet_id              = element(data.aws_subnet.application.*.id, count.index)
+vpc_security_group_ids = [aws_security_group.nginx.id]
 
-  credit_specification {
-    cpu_credits = "unlimited"
-  }
+lifecycle {
+ignore_changes = [ami]
+}
 
-  tags {
-    Name      = "ingress-nginx"
-    terraform = "true"
-    app       = "ingress"
-    env       = "${var.env}"
-  }
+credit_specification {
+cpu_credits = "unlimited"
+}
+
+tags = {
+Name      = "ingress-nginx"
+terraform = "true"
+app       = "ingress"
+env       = var.env
+}
 }
 
 # Security group for nginx
 resource "aws_security_group" "nginx" {
-  name_prefix = "ingress-nginx-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+name_prefix = "ingress-nginx-"
+vpc_id      = data.aws_vpc.vpc.id
 
-  tags {
-    env       = "${var.env}"
-    terraform = "true"
-    app       = "ingress-nginx"
-    Name      = "ingress-nginx"
-  }
+tags = {
+env       = var.env
+terraform = "true"
+app       = "ingress-nginx"
+Name      = "ingress-nginx"
+}
 }
 
 resource "aws_security_group_rule" "nginx_http" {
-  type        = "ingress"
-  from_port   = "80"
-  to_port     = "80"
-  protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+type        = "ingress"
+from_port   = "80"
+to_port     = "80"
+protocol    = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.nginx.id}"
+security_group_id = aws_security_group.nginx.id
 }
 
 resource "aws_security_group_rule" "nginx_https" {
-  type        = "ingress"
-  from_port   = "443"
-  to_port     = "443"
-  protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+type        = "ingress"
+from_port   = "443"
+to_port     = "443"
+protocol    = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.nginx.id}"
+security_group_id = aws_security_group.nginx.id
 }
 
 resource "aws_security_group_rule" "nginx_healthcheck" {
-  type        = "ingress"
-  from_port   = "200"
-  to_port     = "200"
-  protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+type        = "ingress"
+from_port   = "200"
+to_port     = "200"
+protocol    = "tcp"
+cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.nginx.id}"
+security_group_id = aws_security_group.nginx.id
 }
 
 resource "aws_security_group_rule" "nginx_out" {
-  type        = "egress"
-  from_port   = 0
-  to_port     = 0
-  protocol    = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+type        = "egress"
+from_port   = 0
+to_port     = 0
+protocol    = "-1"
+cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.nginx.id}"
+security_group_id = aws_security_group.nginx.id
 }
 
 resource "aws_security_group_rule" "jumpbox" {
-  type                     = "ingress"
-  from_port                = 22
-  to_port                  = 22
-  protocol                 = "tcp"
-  source_security_group_id = "${data.aws_security_group.jumpbox.id}"
+type                     = "ingress"
+from_port                = 22
+to_port                  = 22
+protocol                 = "tcp"
+source_security_group_id = data.aws_security_group.jumpbox.id
 
-  security_group_id = "${aws_security_group.nginx.id}"
+security_group_id = aws_security_group.nginx.id
 }
 
 # Base IAM instance profile
 resource "aws_iam_instance_profile" "iam" {
-  name = "${var.env}-ingress-nginx"
-  role = "${aws_iam_role.iam.name}"
+name = "${var.env}-ingress-nginx"
+role = aws_iam_role.iam.name
 }
 
 # Auth instance profile and roles
 resource "aws_iam_role" "iam" {
-  name = "${var.env}-ingress-nginx"
+name = "${var.env}-ingress-nginx"
 
-  assume_role_policy = <<EOF
+assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -296,11 +298,12 @@ resource "aws_iam_role" "iam" {
     ]
 }
 EOF
+
 }
 
 resource "aws_iam_role_policy_attachment" "ecr" {
-  role       = "${aws_iam_role.iam.name}"
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
+role = aws_iam_role.iam.name
+policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser"
 }
 
 # Give it base teleport permissions
@@ -310,10 +313,10 @@ resource "aws_iam_role_policy_attachment" "ecr" {
 # }
 
 resource "aws_kms_grant" "main" {
-  name              = "${var.env}-ingress-nginx-main"
-  key_id            = "${data.aws_kms_alias.main.target_key_arn}"
-  grantee_principal = "${aws_iam_role.iam.arn}"
-  operations        = ["Decrypt"]
+name = "${var.env}-ingress-nginx-main"
+key_id = data.aws_kms_alias.main.target_key_arn
+grantee_principal = aws_iam_role.iam.arn
+operations = ["Decrypt"]
 }
 
 #######
@@ -321,21 +324,21 @@ resource "aws_kms_grant" "main" {
 #######
 
 resource "aws_route53_record" "external_cname" {
-  zone_id = "${data.aws_route53_zone.external.id}"
-  name    = "helloworld"
-  type    = "CNAME"
-  ttl     = 30
+zone_id = data.aws_route53_zone.external.id
+name = "helloworld"
+type = "CNAME"
+ttl = 30
 
-  records = ["${aws_lb.nlb.dns_name}"]
+records = [aws_lb.nlb.dns_name]
 }
 
 resource "aws_route53_record" "people_staging" {
-  zone_id = "${data.aws_route53_zone.external.id}"
-  name    = "people-staging"
-  type    = "CNAME"
-  ttl     = 30
+zone_id = data.aws_route53_zone.external.id
+name = "people-staging"
+type = "CNAME"
+ttl = 30
 
-  records = ["${aws_lb.nlb.dns_name}"]
+records = [aws_lb.nlb.dns_name]
 }
 
 #######
@@ -343,75 +346,75 @@ resource "aws_route53_record" "people_staging" {
 #######
 
 resource "aws_route53_record" "alb_cname" {
-  zone_id = "${data.aws_route53_zone.internal.id}"
-  name    = "ingress-alb"
-  type    = "CNAME"
-  ttl     = 30
+zone_id = data.aws_route53_zone.internal.id
+name = "ingress-alb"
+type = "CNAME"
+ttl = 30
 
-  records = ["${aws_alb.application_alb.dns_name}"]
+records = [aws_alb.application_alb.dns_name]
 }
 
 resource "aws_alb" "application_alb" {
-  # max 6 characters for name prefix
-  name_prefix     = "app-lb"
-  internal        = true
-  security_groups = ["${aws_security_group.application_alb_sg.id}"]
-  subnets         = ["${data.aws_subnet.public.*.id}"]
+# max 6 characters for name prefix
+name_prefix = "app-lb"
+internal = true
+security_groups = [aws_security_group.application_alb_sg.id]
+subnets = data.aws_subnet.public.*.id
 
-  ip_address_type = "ipv4"
+ip_address_type = "ipv4"
 
-  tags {
-    env       = "${var.env}"
-    terraform = "true"
-    app       = "helloworld"
-    name      = "alb-helloworld"
-  }
+tags = {
+env = var.env
+terraform = "true"
+app = "helloworld"
+name = "alb-helloworld"
+}
 }
 
 resource "aws_alb_listener" "app_http" {
-  load_balancer_arn = "${aws_alb.application_alb.arn}"
-  port              = "80"
-  protocol          = "HTTP"
+load_balancer_arn = aws_alb.application_alb.arn
+port = "80"
+protocol = "HTTP"
 
-  default_action {
-    target_group_arn = "${aws_alb_target_group.application.arn}"
-    type             = "forward"
-  }
+default_action {
+target_group_arn = aws_alb_target_group.application.arn
+type = "forward"
+}
 }
 
 # Security Group: world -> alb
 resource "aws_security_group" "application_alb_sg" {
-  name_prefix = "app-alb-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+name_prefix = "app-alb-"
+vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env       = "${var.env}"
-    terraform = "true"
-    app       = "helloworld"
-    name      = "world->alb-sg-helloworld"
-  }
+tags = {
+env = var.env
+terraform = "true"
+app = "helloworld"
+name = "world->alb-sg-helloworld"
+}
 }
 
 // Allow inbound only to our listening port
 resource "aws_security_group_rule" "lb_ingress" {
-  type                     = "ingress"
-  from_port                = "80"
-  to_port                  = "80"
-  protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.nginx.id}"
+type = "ingress"
+from_port = "80"
+to_port = "80"
+protocol = "tcp"
+source_security_group_id = aws_security_group.nginx.id
 
-  security_group_id = "${aws_security_group.application_alb_sg.id}"
+security_group_id = aws_security_group.application_alb_sg.id
 }
 
 // Allow all outbound by default
 resource "aws_security_group_rule" "lb_egress" {
-  type        = "egress"
-  from_port   = 0
-  to_port     = 0
-  protocol    = "-1"
-  cidr_blocks = ["0.0.0.0/0"]
+type = "egress"
+from_port = 0
+to_port = 0
+protocol = "-1"
+cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.application_alb_sg.id}"
+security_group_id = aws_security_group.application_alb_sg.id
 }
 
 #######
@@ -419,10 +422,10 @@ resource "aws_security_group_rule" "lb_egress" {
 #######
 
 resource "aws_instance" "application" {
-  ami           = "${data.aws_ami.base.id}"
-  instance_type = "t3.micro"
+ami = data.aws_ami.base.id
+instance_type = "t3.micro"
 
-  user_data = <<EOF
+user_data = <<EOF
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -432,26 +435,27 @@ docker run -d --restart=unless-stopped \
   nginxdemos/hello
 EOF
 
+
   key_name = "infrastructure"
 
   associate_public_ip_address = false
 
   #distribute instances across AZs
-  subnet_id              = "${element(data.aws_subnet.application.*.id,count.index)}"
-  vpc_security_group_ids = ["${aws_security_group.app_sg.id}"]
+  subnet_id              = element(data.aws_subnet.application.*.id, count.index)
+  vpc_security_group_ids = [aws_security_group.app_sg.id]
 
   lifecycle {
-    ignore_changes = ["ami"]
+    ignore_changes = [ami]
   }
 
   credit_specification {
     cpu_credits = "unlimited"
   }
 
-  tags {
+  tags = {
     Name = "helloworld-${count.index}"
     app  = "helloworld"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
@@ -460,8 +464,8 @@ resource "aws_alb_target_group" "application" {
   name_prefix = "app-lb"
   port        = "80"
   protocol    = "HTTP"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
-  target_type = "ip"                     # Must use IP to support fargate
+  vpc_id      = data.aws_vpc.vpc.id
+  target_type = "ip" # Must use IP to support fargate
 
   health_check {
     interval            = 60
@@ -471,10 +475,10 @@ resource "aws_alb_target_group" "application" {
     unhealthy_threshold = 2
   }
 
-  depends_on = ["aws_alb.application_alb"]
+  depends_on = [aws_alb.application_alb]
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "helloworld"
     name      = "alb-tg-helloworld:80"
@@ -482,17 +486,17 @@ resource "aws_alb_target_group" "application" {
 }
 
 resource "aws_alb_target_group_attachment" "application_targets" {
-  target_group_arn = "${aws_alb_target_group.application.arn}"
-  target_id        = "${aws_instance.application.private_ip}"
+  target_group_arn = aws_alb_target_group.application.arn
+  target_id        = aws_instance.application.private_ip
 }
 
 resource "aws_security_group" "app_sg" {
   name_prefix = "helloworld-app-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     app = "helloworld"
-    env = "${var.env}"
+    env = var.env
   }
 }
 
@@ -502,9 +506,9 @@ resource "aws_security_group_rule" "app_ingress" {
   from_port                = "80"
   to_port                  = "80"
   protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.application_alb_sg.id}"
+  source_security_group_id = aws_security_group.application_alb_sg.id
 
-  security_group_id = "${aws_security_group.app_sg.id}"
+  security_group_id = aws_security_group.app_sg.id
 }
 
 // Allow all outbound, e.g. third-pary API endpoints, by default
@@ -515,5 +519,6 @@ resource "aws_security_group_rule" "app_egress" {
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.app_sg.id}"
+  security_group_id = aws_security_group.app_sg.id
 }
+

--- a/ingress/main.tf
+++ b/ingress/main.tf
@@ -441,7 +441,7 @@ EOF
   associate_public_ip_address = false
 
   #distribute instances across AZs
-  subnet_id              = element(data.aws_subnet.application.*.id, count.index)
+  subnet_id              = element(data.aws_subnet.application.*.id, 0)
   vpc_security_group_ids = [aws_security_group.app_sg.id]
 
   lifecycle {
@@ -453,7 +453,7 @@ EOF
   }
 
   tags = {
-    Name = "helloworld-${count.index}"
+    Name = "helloworld-0"
     app  = "helloworld"
     env  = var.env
   }

--- a/ingress/variables.tf
+++ b/ingress/variables.tf
@@ -7,7 +7,8 @@ variable "domain_name" {
 }
 
 variable "other_accounts" {
-  type        = "list"
+  type        = list(string)
   description = "OPTIONAL: Additional accounts to give access to the docker repository housing ingress images"
   default     = []
 }
+

--- a/ingress/versions.tf
+++ b/ingress/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/lambda_cron/data.tf
+++ b/lambda_cron/data.tf
@@ -3,21 +3,22 @@ data "aws_s3_bucket" "releases" {
 }
 
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
 data "aws_subnet" "application_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "app-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_kms_alias" "main" {
   name = "alias/${var.env}-main"
 }
+

--- a/lambda_cron/outputs.tf
+++ b/lambda_cron/outputs.tf
@@ -1,4 +1,5 @@
 output "job_iam_role" {
   description = "IAM role name for attaching additional policies to the lambda function with aws_iam_role_policy_attachment"
-  value       = "${aws_iam_role.job.name}"
+  value       = aws_iam_role.job.name
 }
+

--- a/lambda_cron/variables.tf
+++ b/lambda_cron/variables.tf
@@ -30,13 +30,14 @@ variable "memory_size" {
 }
 
 variable "env_vars" {
-  type        = "map"
+  type        = map(string)
   description = "OPTIONAL: a map of environment variables to set for the job"
   default     = {}
 }
 
 variable "secrets" {
-  type        = "list"
+  type        = list(string)
   description = "OPTIONAL: a list of ARNs for Secret Manager secrets to allow job to access"
   default     = []
 }
+

--- a/lambda_cron/versions.tf
+++ b/lambda_cron/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,8 @@
 module "vpc" {
   source = "./vpc"
 
-  env  = "${var.env}"
-  cidr = "${var.cidr}"
+  env  = var.env
+  cidr = var.cidr
 }
 
 #####
@@ -12,15 +12,15 @@ module "vpc" {
 module "encryptkey" {
   source = "./encryptkey"
 
-  env = "${var.env}"
+  env = var.env
 }
 
 module "wildcard" {
   source = "./wildcard_cert"
 
-  env         = "${var.env}"
-  root_domain = "${var.domain_name}"
-  domain      = "${var.domain_name}"
+  env         = var.env
+  root_domain = var.domain_name
+  domain      = var.domain_name
 }
 
 resource "aws_s3_bucket" "lambda_releases" {
@@ -31,9 +31,9 @@ resource "aws_s3_bucket" "lambda_releases" {
     enabled = true
   }
 
-  tags {
-    env         = "${var.env}"
-    domain_name = "${var.domain_name}"
+  tags = {
+    env         = var.env
+    domain_name = var.domain_name
     terraform   = "True"
     app         = "lambda-releases"
   }
@@ -41,12 +41,13 @@ resource "aws_s3_bucket" "lambda_releases" {
 
 resource "aws_security_group" "jumpbox" {
   name_prefix = "jumpbox-"
-  vpc_id      = "${module.vpc.id}"
+  vpc_id      = module.vpc.id
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "utilities"
     Name      = "jumpbox"
   }
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,5 @@
 output "key_arn" {
   description = "ARN of the primary encryption key tied to this environment"
-  value       = "${module.encryptkey.key_arn}"
+  value       = module.encryptkey.key_arn
 }
+

--- a/plain_instance/data.tf
+++ b/plain_instance/data.tf
@@ -1,36 +1,37 @@
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
-data "aws_caller_identity" "current" {}
+data "aws_caller_identity" "current" {
+}
 
 data "aws_subnet" "application_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "app-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_security_group" "ssh_proxies" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env  = "${var.env}"
+  tags = {
+    env  = var.env
     app  = "teleport"
     Name = "teleport-proxies"
   }
 }
 
 data "aws_security_group" "jumpbox" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env  = "${var.env}"
+  tags = {
+    env  = var.env
     app  = "utilities"
     Name = "jumpbox"
   }
@@ -53,3 +54,4 @@ data "aws_ami" "base" {
     values = ["adhoc_base*"]
   }
 }
+

--- a/plain_instance/main.tf
+++ b/plain_instance/main.tf
@@ -1,47 +1,55 @@
 module "base" {
   source = "../app_base"
 
-  env               = "${var.env}"
-  domain_name       = "${var.domain_name}"
-  application_name  = "${var.application_name}"
-  application_port  = "${var.application_port}"
-  loadbalancer_port = "${var.loadbalancer_port}"
+  env               = var.env
+  domain_name       = var.domain_name
+  application_name  = var.application_name
+  application_port  = var.application_port
+  loadbalancer_port = var.loadbalancer_port
 }
 
 resource "aws_instance" "application" {
-  count         = "${var.instance_count}"
-  ami           = "${data.aws_ami.base.id}"
-  instance_type = "${var.instance_size}"
+  count         = var.instance_count
+  ami           = data.aws_ami.base.id
+  instance_type = var.instance_size
 
-  iam_instance_profile = "${aws_iam_instance_profile.iam.name}"
-  user_data            = "${var.user_data}"
-  key_name             = "${var.key_pair}"
+  iam_instance_profile = aws_iam_instance_profile.iam.name
+  user_data            = var.user_data
+  key_name             = var.key_pair
 
   associate_public_ip_address = false
 
   #distribute instances across AZs
-  subnet_id              = "${element(data.aws_subnet.application_subnet.*.id,count.index)}"
-  vpc_security_group_ids = ["${module.base.app_sg_id}"]
+  subnet_id = element(data.aws_subnet.application_subnet.*.id, count.index)
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibilty in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  vpc_security_group_ids = [module.base.app_sg_id]
 
   lifecycle {
-    ignore_changes = ["ami"]
+    ignore_changes = [ami]
   }
 
   credit_specification {
     cpu_credits = "unlimited"
   }
 
-  tags {
+  tags = {
     Name = "${var.application_name}-${count.index}"
-    app  = "${var.application_name}"
-    env  = "${var.env}"
+    app  = var.application_name
+    env  = var.env
   }
 }
 
 resource "aws_alb_target_group_attachment" "application_targets" {
-  count            = "${var.instance_count}"
-  target_group_arn = "${module.base.lb_tg_arn}"
-  target_id        = "${element(aws_instance.application.*.private_ip, count.index)}"
+  count            = var.instance_count
+  target_group_arn = module.base.lb_tg_arn
+  target_id        = element(aws_instance.application.*.private_ip, count.index)
 }
 
 # Add rule to allow SSH proxies to connect
@@ -50,9 +58,9 @@ resource "aws_security_group_rule" "proxy_ssh" {
   from_port                = 3022
   to_port                  = 3022
   protocol                 = "tcp"
-  source_security_group_id = "${data.aws_security_group.ssh_proxies.id}"
+  source_security_group_id = data.aws_security_group.ssh_proxies.id
 
-  security_group_id = "${module.base.app_sg_id}"
+  security_group_id = module.base.app_sg_id
 }
 
 resource "aws_security_group_rule" "jumpbox" {
@@ -60,9 +68,9 @@ resource "aws_security_group_rule" "jumpbox" {
   from_port                = 22
   to_port                  = 22
   protocol                 = "tcp"
-  source_security_group_id = "${data.aws_security_group.jumpbox.id}"
+  source_security_group_id = data.aws_security_group.jumpbox.id
 
-  security_group_id = "${module.base.app_sg_id}"
+  security_group_id = module.base.app_sg_id
 }
 
 #####
@@ -70,7 +78,7 @@ resource "aws_security_group_rule" "jumpbox" {
 #####
 resource "aws_iam_instance_profile" "iam" {
   name = "${var.env}-plain-instance"
-  role = "${aws_iam_role.iam.name}"
+  role = aws_iam_role.iam.name
 }
 
 # Auth instance profile and roles
@@ -89,17 +97,19 @@ resource "aws_iam_role" "iam" {
     ]
 }
 EOF
+
 }
 
 # Give it base teleport permissions
 resource "aws_iam_role_policy_attachment" "iam_teleport" {
-  role       = "${aws_iam_role.iam.name}"
+  role = aws_iam_role.iam.name
   policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.env}/teleport/${var.env}-instance-teleport-secrets"
 }
 
 resource "aws_kms_grant" "main" {
-  name              = "${var.env}-${var.application_name}-main"
-  key_id            = "${data.aws_kms_alias.main.target_key_arn}"
-  grantee_principal = "${aws_iam_role.iam.arn}"
-  operations        = ["Decrypt"]
+  name = "${var.env}-${var.application_name}-main"
+  key_id = data.aws_kms_alias.main.target_key_arn
+  grantee_principal = aws_iam_role.iam.arn
+  operations = ["Decrypt"]
 }
+

--- a/plain_instance/main.tf
+++ b/plain_instance/main.tf
@@ -20,15 +20,7 @@ resource "aws_instance" "application" {
   associate_public_ip_address = false
 
   #distribute instances across AZs
-  subnet_id = element(data.aws_subnet.application_subnet.*.id, count.index)
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibilty in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
+  subnet_id              = element(data.aws_subnet.application_subnet.*.id, count.index)
   vpc_security_group_ids = [module.base.app_sg_id]
 
   lifecycle {

--- a/plain_instance/outputs.tf
+++ b/plain_instance/outputs.tf
@@ -1,8 +1,9 @@
 output "app_sg_id" {
-  value = "${module.base.app_sg_id}"
+  value = module.base.app_sg_id
 }
 
 output "instance_iam_role" {
   description = "IAM role name for attaching additional policies to the instance with aws_iam_role_policy_attachment"
-  value       = "${aws_iam_role.iam.name}"
+  value       = aws_iam_role.iam.name
 }
+

--- a/plain_instance/variables.tf
+++ b/plain_instance/variables.tf
@@ -39,3 +39,4 @@ variable "user_data" {
   description = "OPTIONAL: user data script to run on initialization"
   default     = ""
 }
+

--- a/plain_instance/versions.tf
+++ b/plain_instance/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/soapbox_managed/main.tf
+++ b/soapbox_managed/main.tf
@@ -1,3 +1,0 @@
-module "base" {
-  source = "../app_base"
-}

--- a/static_site/data.tf
+++ b/static_site/data.tf
@@ -1,10 +1,11 @@
 # Pull in data from outside terraform (the public zone and certificate must already exist in the account)
 data "aws_route53_zone" "domain" {
-  name         = "${var.domain_name}"
+  name         = var.domain_name
   private_zone = false
 }
 
 data "aws_acm_certificate" "wildcard" {
-  domain      = "${var.domain_name}"
+  domain      = var.domain_name
   most_recent = true
 }
+

--- a/static_site/main.tf
+++ b/static_site/main.tf
@@ -5,24 +5,24 @@
 # Setup DNS records for the static site
 
 resource "aws_route53_record" "subdomain" {
-  zone_id = "${data.aws_route53_zone.domain.zone_id}"
-  name    = "${var.subdomain}"
+  zone_id = data.aws_route53_zone.domain.zone_id
+  name    = var.subdomain
   type    = "CNAME"
   ttl     = "300"
 
-  records = ["${aws_cloudfront_distribution.s3_distribution.domain_name}"]
+  records = [aws_cloudfront_distribution.s3_distribution.domain_name]
 }
 
 # # If we're setting, www (e.g., www.example.com) then also direct the apex domain (example.com)
 resource "aws_route53_record" "apex_domain" {
-  count   = "${var.subdomain == "www" ? 1 : 0}"
-  zone_id = "${data.aws_route53_zone.domain.zone_id}"
+  count   = var.subdomain == "www" ? 1 : 0
+  zone_id = data.aws_route53_zone.domain.zone_id
   name    = ""
   type    = "A"
 
   alias {
-    name                   = "${aws_cloudfront_distribution.s3_distribution.domain_name}"
-    zone_id                = "${aws_cloudfront_distribution.s3_distribution.hosted_zone_id}"
+    name                   = aws_cloudfront_distribution.s3_distribution.domain_name
+    zone_id                = aws_cloudfront_distribution.s3_distribution.hosted_zone_id
     evaluate_target_health = false
   }
 }
@@ -52,16 +52,17 @@ resource "aws_s3_bucket" "site_content_bucket" {
 }
 POLICY
 
+
   # Serve index.html on errors to support client side routing, e.g. React Router
   website {
     index_document = "index.html"
     error_document = "index.html"
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env = var.env
     terraform = "true"
-    name      = "${var.subdomain}.${var.domain_name}"
+    name = "${var.subdomain}.${var.domain_name}"
   }
 }
 
@@ -69,31 +70,31 @@ POLICY
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = "${aws_s3_bucket.site_content_bucket.bucket_domain_name}"
-    origin_id   = "${var.subdomain}-${var.domain_name}"
+    domain_name = aws_s3_bucket.site_content_bucket.bucket_domain_name
+    origin_id = "${var.subdomain}-${var.domain_name}"
   }
 
-  enabled             = true
+  enabled = true
   default_root_object = "index.html"
 
   aliases = ["${var.subdomain}.${var.domain_name}"]
 
   # Serve index.html on errors to support client side routing, e.g. React Router
   custom_error_response {
-    error_code         = 403
-    response_code      = 200
+    error_code = 403
+    response_code = 200
     response_page_path = "/index.html"
   }
 
   custom_error_response {
-    error_code         = 404
-    response_code      = 200
+    error_code = 404
+    response_code = 200
     response_page_path = "/index.html"
   }
 
   default_cache_behavior {
-    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD"]
+    allowed_methods = ["GET", "HEAD", "OPTIONS"]
+    cached_methods = ["GET", "HEAD"]
     target_origin_id = "${var.subdomain}-${var.domain_name}"
 
     # Use gzip compression
@@ -108,14 +109,14 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     }
 
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 0
-    default_ttl            = 60
-    max_ttl                = 60
+    min_ttl = 0
+    default_ttl = 60
+    max_ttl = 60
   }
 
   viewer_certificate {
-    acm_certificate_arn = "${data.aws_acm_certificate.wildcard.arn}"
-    ssl_support_method  = "sni-only"
+    acm_certificate_arn = data.aws_acm_certificate.wildcard.arn
+    ssl_support_method = "sni-only"
   }
 
   restrictions {
@@ -124,10 +125,10 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
     }
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env = var.env
     terraform = "true"
-    name      = "cdn-${var.subdomain}.${var.domain_name}"
+    name = "cdn-${var.subdomain}.${var.domain_name}"
   }
 }
 
@@ -136,19 +137,19 @@ resource "aws_cloudfront_distribution" "s3_distribution" {
 ####
 
 resource "aws_route53_record" "preview" {
-  zone_id = "${data.aws_route53_zone.domain.zone_id}"
-  name    = "preview.${var.subdomain}"
-  type    = "CNAME"
-  ttl     = "300"
+  zone_id = data.aws_route53_zone.domain.zone_id
+  name = "preview.${var.subdomain}"
+  type = "CNAME"
+  ttl = "300"
 
-  records = ["${aws_s3_bucket.preview.website_endpoint}"]
+  records = [aws_s3_bucket.preview.website_endpoint]
 }
 
 # Create bucket to host the content
 
 resource "aws_s3_bucket" "preview" {
   bucket = "preview.${var.subdomain}.${var.domain_name}"
-  acl    = "public-read"
+  acl = "public-read"
 
   policy = <<POLICY
 {
@@ -169,15 +170,17 @@ resource "aws_s3_bucket" "preview" {
 }
 POLICY
 
-  # Serve index.html on errors to support client side routing, e.g. React Router
-  website {
-    index_document = "index.html"
-    error_document = "index.html"
-  }
 
-  tags {
-    env       = "${var.env}"
-    terraform = "true"
-    name      = "preview.${var.subdomain}.${var.domain_name}"
-  }
+# Serve index.html on errors to support client side routing, e.g. React Router
+website {
+index_document = "index.html"
+error_document = "index.html"
 }
+
+tags = {
+env       = var.env
+terraform = "true"
+name      = "preview.${var.subdomain}.${var.domain_name}"
+}
+}
+

--- a/static_site/outputs.tf
+++ b/static_site/outputs.tf
@@ -1,11 +1,12 @@
 output "cdn_url" {
-  value = "${aws_cloudfront_distribution.s3_distribution.domain_name}"
+  value = aws_cloudfront_distribution.s3_distribution.domain_name
 }
 
 output "bucket_url" {
-  value = "${aws_s3_bucket.site_content_bucket.bucket_domain_name}"
+  value = aws_s3_bucket.site_content_bucket.bucket_domain_name
 }
 
 output "content_bucket" {
-  value = "${aws_s3_bucket.site_content_bucket.bucket}"
+  value = aws_s3_bucket.site_content_bucket.bucket
 }
+

--- a/static_site/variables.tf
+++ b/static_site/variables.tf
@@ -9,3 +9,4 @@ variable "subdomain" {
 variable "domain_name" {
   default = ""
 }
+

--- a/static_site/versions.tf
+++ b/static_site/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/test/all.tf
+++ b/test/all.tf
@@ -7,7 +7,7 @@ variable "region" {
 }
 
 provider "aws" {
-  region  = "${var.region}"
+  region  = var.region
   version = "~> 2.13.0"
 }
 
@@ -19,45 +19,45 @@ locals {
 module "base" {
   source = "../"
 
-  env         = "${local.env}"
-  domain_name = "${local.domain_name}"
+  env         = local.env
+  domain_name = local.domain_name
 }
 
 module "utilities" {
   source = "../utilities"
 
-  env         = "${local.env}"
-  domain_name = "${local.domain_name}"
+  env         = local.env
+  domain_name = local.domain_name
 }
 
 module "ingress" {
   source = "../ingress"
 
-  env         = "${local.env}"
-  domain_name = "${local.domain_name}"
+  env         = local.env
+  domain_name = local.domain_name
 }
 
 module "static" {
   source = "../static_site"
 
-  env         = "${local.env}"
-  domain_name = "${local.domain_name}"
+  env         = local.env
+  domain_name = local.domain_name
   subdomain   = "pizza"
 }
 
 module "demo" {
   source = "../plain_instance"
 
-  env              = "${local.env}"
-  domain_name      = "${local.domain_name}"
+  env              = local.env
+  domain_name      = local.domain_name
   application_name = "demo"
 }
 
 module "fargate" {
   source = "../fargate_cluster"
 
-  env              = "${local.env}"
-  domain_name      = "${local.domain_name}"
+  env              = local.env
+  domain_name      = local.domain_name
   application_name = "web"
   docker_image     = "nginx:latest"
 }
@@ -70,17 +70,17 @@ variable "db_password" {
 module "postgres" {
   source = "../database"
 
-  env              = "${local.env}"
+  env              = local.env
   application_name = "demo"
-  app_sg           = "${module.demo.app_sg_id}"
+  app_sg           = module.demo.app_sg_id
   password         = "{$var.db_password}"
 }
 
 module "lambda_cron" {
   source = "../lambda_cron"
 
-  env             = "${local.env}"
-  domain_name     = "${local.domain_name}"
+  env             = local.env
+  domain_name     = local.domain_name
   job_name        = "crontab"
   cron_expression = "* * ? * * *"
 
@@ -99,13 +99,14 @@ module "production" {
   source = "../"
 
   env         = "prod"
-  domain_name = "${local.domain_name}"
+  domain_name = local.domain_name
 }
 
 module "teleport_subcluster" {
   source = "../utilities/teleport_subcluster"
 
   env          = "prod"
-  domain_name  = "${local.domain_name}"
-  main_cluster = "${local.env}"
+  domain_name  = local.domain_name
+  main_cluster = local.env
 }
+

--- a/test/all.tf
+++ b/test/all.tf
@@ -8,7 +8,7 @@ variable "region" {
 
 provider "aws" {
   region  = "${var.region}"
-  version = "~> 1.42"
+  version = "~> 2.13.0"
 }
 
 locals {

--- a/test/versions.tf
+++ b/test/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/utilities/jenkins/data.tf
+++ b/utilities/jenkins/data.tf
@@ -1,31 +1,31 @@
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
 data "aws_subnet" "application_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "app-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_subnet" "public_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "public-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_route53_zone" "external" {
-  name         = "${var.domain_name}"
+  name         = var.domain_name
   private_zone = false
 }
 
@@ -35,7 +35,7 @@ data "aws_route53_zone" "internal" {
 }
 
 data "aws_acm_certificate" "wildcard" {
-  domain      = "${var.domain_name}"
+  domain      = var.domain_name
   most_recent = true
 }
 
@@ -68,10 +68,10 @@ data "aws_kms_alias" "main" {
 }
 
 data "aws_security_group" "jumpbox" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env  = "${var.env}"
+  tags = {
+    env  = var.env
     app  = "utilities"
     Name = "jumpbox"
   }
@@ -86,3 +86,4 @@ data "aws_ami" "base" {
     values = ["adhoc_base*"]
   }
 }
+

--- a/utilities/jenkins/main.tf
+++ b/utilities/jenkins/main.tf
@@ -5,17 +5,17 @@
 
 locals {
   default_url = "jenkins.${var.env}.${var.domain_name}"
-  url         = "${coalesce(var.jenkins_url, local.default_url)}"
+  url         = coalesce(var.jenkins_url, local.default_url)
 }
 
 resource "aws_alb" "jenkins" {
   name            = "jenkins-load-balancer"
   internal        = false
-  security_groups = ["${aws_security_group.alb.id}"]
-  subnets         = ["${data.aws_subnet.public_subnet.*.id}"]
+  security_groups = [aws_security_group.alb.id]
+  subnets         = data.aws_subnet.public_subnet.*.id
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     Name      = "jenkins-load-balancer"
     app       = "jenkins"
@@ -24,7 +24,7 @@ resource "aws_alb" "jenkins" {
 
 resource "aws_alb_target_group" "primary" {
   name     = "alb-jenkins-target"
-  vpc_id   = "${data.aws_vpc.vpc.id}"
+  vpc_id   = data.aws_vpc.vpc.id
   port     = "8080"
   protocol = "HTTP"
 
@@ -39,8 +39,8 @@ resource "aws_alb_target_group" "primary" {
     matcher             = "200-308"
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     Name      = "jenkins-load-balancer"
     app       = "jenkins"
@@ -48,7 +48,7 @@ resource "aws_alb_target_group" "primary" {
 }
 
 resource "aws_lb_listener" "redirect_to_https" {
-  load_balancer_arn = "${aws_alb.jenkins.arn}"
+  load_balancer_arn = aws_alb.jenkins.arn
   port              = "80"
   protocol          = "HTTP"
 
@@ -65,48 +65,48 @@ resource "aws_lb_listener" "redirect_to_https" {
 
 # Assign domain name
 resource "aws_route53_record" "alb" {
-  zone_id = "${data.aws_route53_zone.external.id}"
-  name    = "${local.url}"
+  zone_id = data.aws_route53_zone.external.id
+  name    = local.url
   type    = "CNAME"
   ttl     = 30
 
-  records = ["${aws_alb.jenkins.dns_name}"]
+  records = [aws_alb.jenkins.dns_name]
 }
 
 module "cert" {
   source = "../../wildcard_cert"
 
-  env         = "${var.env}"
-  root_domain = "${var.domain_name}"
-  domain      = "${local.default_url}"
+  env         = var.env
+  root_domain = var.domain_name
+  domain      = local.default_url
 }
 
 resource "aws_alb_listener" "https" {
-  load_balancer_arn = "${aws_alb.jenkins.arn}"
+  load_balancer_arn = aws_alb.jenkins.arn
   port              = "443"
   protocol          = "HTTPS"
   ssl_policy        = "ELBSecurityPolicy-2016-08"
-  certificate_arn   = "${module.cert.arn}"
+  certificate_arn   = module.cert.arn
 
   default_action {
-    target_group_arn = "${aws_alb_target_group.primary.arn}"
+    target_group_arn = aws_alb_target_group.primary.arn
     type             = "forward"
   }
 }
 
 # Also allow it serve direct subdomains like jenkins.domain_name
 resource "aws_alb_listener_certificate" "domain_name" {
-  listener_arn    = "${aws_alb_listener.https.arn}"
-  certificate_arn = "${data.aws_acm_certificate.wildcard.arn}"
+  listener_arn    = aws_alb_listener.https.arn
+  certificate_arn = data.aws_acm_certificate.wildcard.arn
 }
 
 # Security group
 resource "aws_security_group" "alb" {
   name_prefix = "$jenkins-alb-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "jenkins"
     role      = "alb"
@@ -120,7 +120,7 @@ resource "aws_security_group_rule" "alb_tls" {
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.alb.id}"
+  security_group_id = aws_security_group.alb.id
 }
 
 resource "aws_security_group_rule" "alb_http" {
@@ -130,7 +130,7 @@ resource "aws_security_group_rule" "alb_http" {
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.alb.id}"
+  security_group_id = aws_security_group.alb.id
 }
 
 resource "aws_security_group_rule" "alb_egress" {
@@ -140,7 +140,7 @@ resource "aws_security_group_rule" "alb_egress" {
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.alb.id}"
+  security_group_id = aws_security_group.alb.id
 }
 
 #######
@@ -148,15 +148,15 @@ resource "aws_security_group_rule" "alb_egress" {
 #######
 
 resource "aws_instance" "jenkins_primary" {
-  ami           = "${data.aws_ami.base.id}"
+  ami           = data.aws_ami.base.id
   instance_type = "t3.small"
   key_name      = "infrastructure"
 
   associate_public_ip_address = false
-  subnet_id                   = "${element(data.aws_subnet.application_subnet.*.id,1)}"
-  vpc_security_group_ids      = ["${aws_security_group.jenkins_primary.id}"]
+  subnet_id                   = element(data.aws_subnet.application_subnet.*.id, 1)
+  vpc_security_group_ids      = [aws_security_group.jenkins_primary.id]
 
-  iam_instance_profile = "${aws_iam_instance_profile.primary.name}"
+  iam_instance_profile = aws_iam_instance_profile.primary.name
 
   user_data = <<-EOF
               #!/usr/bin/env bash
@@ -174,113 +174,114 @@ resource "aws_instance" "jenkins_primary" {
                 -e docker_password="${data.aws_secretsmanager_secret_version.docker_password.secret_string}" \
                 -e slack_token="${data.aws_secretsmanager_secret_version.slack_token.secret_string}" \
                 ${var.jenkins_image}
-              EOF
+EOF
+
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = 20
+    volume_type = "gp2"
+    volume_size = 20
     delete_on_termination = true
   }
 
   lifecycle {
-    ignore_changes = ["ami"]
+    ignore_changes = [ami]
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env = var.env
     terraform = "true"
-    Name      = "jenkins-primary"
-    app       = "jenkins"
-    role      = "primary"
+    Name = "jenkins-primary"
+    app = "jenkins"
+    role = "primary"
   }
 }
 
 # Convenient internal DNS name for other items in VPC to use if needed
 resource "aws_route53_record" "primary" {
-  zone_id = "${data.aws_route53_zone.internal.id}"
-  name    = "primary.jenkins"
-  type    = "CNAME"
-  ttl     = 30
+  zone_id = data.aws_route53_zone.internal.id
+  name = "primary.jenkins"
+  type = "CNAME"
+  ttl = 30
 
-  records = ["${aws_instance.jenkins_primary.private_dns}"]
+  records = [aws_instance.jenkins_primary.private_dns]
 }
 
 resource "aws_lb_target_group_attachment" "primary" {
-  target_group_arn = "${aws_alb_target_group.primary.arn}"
-  target_id        = "${aws_instance.jenkins_primary.id}"
-  port             = 8080
+  target_group_arn = aws_alb_target_group.primary.arn
+  target_id = aws_instance.jenkins_primary.id
+  port = 8080
 }
 
 resource "aws_security_group" "jenkins_primary" {
   name_prefix = "$jenkins-primary-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env = var.env
     terraform = "true"
-    app       = "jenkins"
-    role      = "primary"
+    app = "jenkins"
+    role = "primary"
   }
 }
 
 resource "aws_security_group_rule" "primary_proxy_ssh" {
-  type                     = "ingress"
-  from_port                = 3022
-  to_port                  = 3022
-  protocol                 = "tcp"
-  source_security_group_id = "${var.ssh_proxy_sg}"
+  type = "ingress"
+  from_port = 3022
+  to_port = 3022
+  protocol = "tcp"
+  source_security_group_id = var.ssh_proxy_sg
 
-  security_group_id = "${aws_security_group.jenkins_primary.id}"
+  security_group_id = aws_security_group.jenkins_primary.id
 }
 
 resource "aws_security_group_rule" "primary_ssh_ingress" {
-  type                     = "ingress"
-  from_port                = 22
-  to_port                  = 22
-  protocol                 = "tcp"
-  source_security_group_id = "${data.aws_security_group.jumpbox.id}"
+  type = "ingress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  source_security_group_id = data.aws_security_group.jumpbox.id
 
-  security_group_id = "${aws_security_group.jenkins_primary.id}"
+  security_group_id = aws_security_group.jenkins_primary.id
 }
 
 resource "aws_security_group_rule" "alb_to_primary" {
-  type                     = "ingress"
-  from_port                = 8080
-  to_port                  = 8080
-  protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.alb.id}"
+  type = "ingress"
+  from_port = 8080
+  to_port = 8080
+  protocol = "tcp"
+  source_security_group_id = aws_security_group.alb.id
 
-  security_group_id = "${aws_security_group.jenkins_primary.id}"
+  security_group_id = aws_security_group.jenkins_primary.id
 }
 
 resource "aws_security_group_rule" "worker_to_primary_http" {
-  type                     = "ingress"
-  from_port                = 8080
-  to_port                  = 8080
-  protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.jenkins_worker.id}"
+  type = "ingress"
+  from_port = 8080
+  to_port = 8080
+  protocol = "tcp"
+  source_security_group_id = aws_security_group.jenkins_worker.id
 
-  security_group_id = "${aws_security_group.jenkins_primary.id}"
+  security_group_id = aws_security_group.jenkins_primary.id
 }
 
 resource "aws_security_group_rule" "worker_to_primary_jnlp" {
-  type                     = "ingress"
-  from_port                = 50000
-  to_port                  = 50000
-  protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.jenkins_worker.id}"
+  type = "ingress"
+  from_port = 50000
+  to_port = 50000
+  protocol = "tcp"
+  source_security_group_id = aws_security_group.jenkins_worker.id
 
-  security_group_id = "${aws_security_group.jenkins_primary.id}"
+  security_group_id = aws_security_group.jenkins_primary.id
 }
 
 resource "aws_security_group_rule" "primary_egress" {
-  type        = "egress"
-  from_port   = 0
-  to_port     = 0
-  protocol    = "-1"
+  type = "egress"
+  from_port = 0
+  to_port = 0
+  protocol = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.jenkins_primary.id}"
+  security_group_id = aws_security_group.jenkins_primary.id
 }
 
 #######
@@ -288,105 +289,105 @@ resource "aws_security_group_rule" "primary_egress" {
 #######
 
 data "template_file" "jenkins_worker" {
-  count    = "${length(var.workers)}"
-  template = "${file("${path.module}/worker.tmpl")}"
+  count = length(var.workers)
+  template = file("${path.module}/worker.tmpl")
 
-  vars {
-    count     = "${count.index}"
-    master    = "http://${aws_route53_record.primary.fqdn}:8080"
-    label     = "${element(split(",", element(var.workers, count.index)), 0)}"
-    username  = "${var.github_user}"
-    password  = "${data.aws_secretsmanager_secret_version.github_password.secret_string}"
-    executors = "${element(split(",", element(var.workers, count.index)), 2)}"
+  vars = {
+    count = count.index
+    master = "http://${aws_route53_record.primary.fqdn}:8080"
+    label = element(split(",", element(var.workers, count.index)), 0)
+    username = var.github_user
+    password = data.aws_secretsmanager_secret_version.github_password.secret_string
+    executors = element(split(",", element(var.workers, count.index)), 2)
   }
 }
 
 resource "aws_instance" "jenkins_worker" {
-  count         = "${length(var.workers)}"
-  ami           = "${data.aws_ami.base.id}"
-  instance_type = "${element(split(",", element(var.workers, count.index)), 1)}"
-  key_name      = "infrastructure"
+  count = length(var.workers)
+  ami = data.aws_ami.base.id
+  instance_type = element(split(",", element(var.workers, count.index)), 1)
+  key_name = "infrastructure"
 
-  iam_instance_profile = "${aws_iam_instance_profile.worker.name}"
-  user_data            = "${element(data.template_file.jenkins_worker.*.rendered, count.index)}"
+  iam_instance_profile = aws_iam_instance_profile.worker.name
+  user_data = element(data.template_file.jenkins_worker.*.rendered, count.index)
 
   associate_public_ip_address = false
-  subnet_id                   = "${element(data.aws_subnet.application_subnet.*.id,count.index)}" #distribute workers across AZs
-  vpc_security_group_ids      = ["${aws_security_group.jenkins_worker.id}"]
+  subnet_id = element(data.aws_subnet.application_subnet.*.id, count.index) #distribute workers across AZs
+  vpc_security_group_ids = [aws_security_group.jenkins_worker.id]
 
   root_block_device {
-    volume_type           = "gp2"
-    volume_size           = 40
+    volume_type = "gp2"
+    volume_size = 40
     delete_on_termination = true
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env = var.env
     terraform = "true"
-    Name      = "jenkins-${element(split(",", element(var.workers, count.index)), 0)}-${count.index}"
-    app       = "jenkins"
-    label     = "${element(split(",", element(var.workers, count.index)), 0)}"
-    role      = "worker"
+    Name = "jenkins-${element(split(",", element(var.workers, count.index)), 0)}-${count.index}"
+    app = "jenkins"
+    label = element(split(",", element(var.workers, count.index)), 0)
+    role = "worker"
   }
 
-  depends_on = ["aws_instance.jenkins_primary"]
+  depends_on = [aws_instance.jenkins_primary]
 
   lifecycle {
-    ignore_changes = ["ami"]
+    ignore_changes = [ami]
   }
 }
 
 # Internal DNS references to each worker node
 resource "aws_route53_record" "worker" {
-  count   = "${length(var.workers)}"
-  zone_id = "${data.aws_route53_zone.internal.id}"
-  name    = "${element(split(",", element(var.workers, count.index)), 0)}-${count.index}.jenkins"
-  type    = "CNAME"
-  ttl     = 30
+  count = length(var.workers)
+  zone_id = data.aws_route53_zone.internal.id
+  name = "${element(split(",", element(var.workers, count.index)), 0)}-${count.index}.jenkins"
+  type = "CNAME"
+  ttl = 30
 
-  records = ["${element(aws_instance.jenkins_worker.*.private_dns, count.index)}"]
+  records = [element(aws_instance.jenkins_worker.*.private_dns, count.index)]
 }
 
 resource "aws_security_group" "jenkins_worker" {
   name_prefix = "$jenkins-worker-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env = var.env
     terraform = "true"
-    app       = "jenkins"
-    role      = "worker"
+    app = "jenkins"
+    role = "worker"
   }
 }
 
 resource "aws_security_group_rule" "worker_proxy_ssh" {
-  type                     = "ingress"
-  from_port                = 3022
-  to_port                  = 3022
-  protocol                 = "tcp"
-  source_security_group_id = "${var.ssh_proxy_sg}"
+  type = "ingress"
+  from_port = 3022
+  to_port = 3022
+  protocol = "tcp"
+  source_security_group_id = var.ssh_proxy_sg
 
-  security_group_id = "${aws_security_group.jenkins_worker.id}"
+  security_group_id = aws_security_group.jenkins_worker.id
 }
 
 resource "aws_security_group_rule" "worker_ssh_ingress" {
-  type                     = "ingress"
-  from_port                = 22
-  to_port                  = 22
-  protocol                 = "tcp"
-  source_security_group_id = "${data.aws_security_group.jumpbox.id}"
+  type = "ingress"
+  from_port = 22
+  to_port = 22
+  protocol = "tcp"
+  source_security_group_id = data.aws_security_group.jumpbox.id
 
-  security_group_id = "${aws_security_group.jenkins_worker.id}"
+  security_group_id = aws_security_group.jenkins_worker.id
 }
 
 resource "aws_security_group_rule" "worker_egress" {
-  type        = "egress"
-  from_port   = 0
-  to_port     = 0
-  protocol    = "-1"
+  type = "egress"
+  from_port = 0
+  to_port = 0
+  protocol = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.jenkins_worker.id}"
+  security_group_id = aws_security_group.jenkins_worker.id
 }
 
 #######
@@ -396,7 +397,7 @@ resource "aws_security_group_rule" "worker_egress" {
 ### Primary
 resource "aws_iam_instance_profile" "primary" {
   name = "${var.env}-jenkins-primary"
-  role = "${aws_iam_role.primary.name}"
+  role = aws_iam_role.primary.name
 }
 
 # Auth instance profile and roles
@@ -415,25 +416,26 @@ resource "aws_iam_role" "primary" {
     ]
 }
 EOF
+
 }
 
 # Give it base teleport permissions
 resource "aws_iam_role_policy_attachment" "primary_teleport" {
-  role       = "${aws_iam_role.primary.name}"
-  policy_arn = "${aws_iam_policy.teleport_secrets.arn}"
+role       = aws_iam_role.primary.name
+policy_arn = aws_iam_policy.teleport_secrets.arn
 }
 
 ### Worker
 resource "aws_iam_instance_profile" "worker" {
-  name = "${var.env}-jenkins-worker"
-  role = "${aws_iam_role.worker.name}"
+name = "${var.env}-jenkins-worker"
+role = aws_iam_role.worker.name
 }
 
 # Auth instance profile and roles
 resource "aws_iam_role" "worker" {
-  name = "${var.env}-jenkins-worker"
+name = "${var.env}-jenkins-worker"
 
-  assume_role_policy = <<EOF
+assume_role_policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -445,21 +447,22 @@ resource "aws_iam_role" "worker" {
     ]
 }
 EOF
+
 }
 
 # Give it base teleport permissions
 resource "aws_iam_role_policy_attachment" "worker_teleport" {
-  role       = "${aws_iam_role.worker.name}"
-  policy_arn = "${aws_iam_policy.teleport_secrets.arn}"
+role = aws_iam_role.worker.name
+policy_arn = aws_iam_policy.teleport_secrets.arn
 }
 
 ### Shared IAM role for teleport
 resource "aws_iam_policy" "teleport_secrets" {
-  name        = "jenkins-teleport-secrets"
-  path        = "/${var.env}/jenkins/"
-  description = "Allows nodes to run local teleport daemon"
+name = "jenkins-teleport-secrets"
+path = "/${var.env}/jenkins/"
+description = "Allows nodes to run local teleport daemon"
 
-  policy = <<EOF
+policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -481,18 +484,20 @@ resource "aws_iam_policy" "teleport_secrets" {
     ]
 }
 EOF
+
 }
 
 resource "aws_kms_grant" "primary" {
   name              = "jenkins-primary-main"
-  key_id            = "${data.aws_kms_alias.main.target_key_arn}"
-  grantee_principal = "${aws_iam_role.primary.arn}"
+  key_id            = data.aws_kms_alias.main.target_key_arn
+  grantee_principal = aws_iam_role.primary.arn
   operations        = ["Decrypt"]
 }
 
 resource "aws_kms_grant" "worker" {
   name              = "jenkins-worker-main"
-  key_id            = "${data.aws_kms_alias.main.target_key_arn}"
-  grantee_principal = "${aws_iam_role.worker.arn}"
+  key_id            = data.aws_kms_alias.main.target_key_arn
+  grantee_principal = aws_iam_role.worker.arn
   operations        = ["Decrypt"]
 }
+

--- a/utilities/jenkins/outputs.tf
+++ b/utilities/jenkins/outputs.tf
@@ -1,4 +1,5 @@
 output "worker_iam_role" {
   description = "IAM role name for attaching additional policies for the worker with aws_iam_role_policy_attachment"
-  value       = "${aws_iam_role.worker.name}"
+  value       = aws_iam_role.worker.name
 }
+

--- a/utilities/jenkins/variables.tf
+++ b/utilities/jenkins/variables.tf
@@ -39,3 +39,4 @@ variable "jenkins_image" {
   description = "OPTIONAL: the image name for the container to use for the jenkins primary"
   default     = "adhocteam/jenkins:latest"
 }
+

--- a/utilities/jenkins/versions.tf
+++ b/utilities/jenkins/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/utilities/jumpbox/data.tf
+++ b/utilities/jumpbox/data.tf
@@ -3,31 +3,31 @@
 #######
 
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
 data "aws_subnet" "public_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "public-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_route53_zone" "external" {
-  name         = "${var.domain_name}"
+  name         = var.domain_name
   private_zone = false
 }
 
 data "aws_security_group" "jumpbox" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env  = "${var.env}"
+  tags = {
+    env  = var.env
     app  = "utilities"
     Name = "jumpbox"
   }
@@ -42,3 +42,4 @@ data "aws_ami" "amazon_linux_2" {
     values = ["amzn2-ami-hvm-*-x86_64*"]
   }
 }
+

--- a/utilities/jumpbox/variables.tf
+++ b/utilities/jumpbox/variables.tf
@@ -15,3 +15,4 @@ variable "enabled" {
   description = "OPTIONAL: set to true to enable jumpbox"
   default     = false
 }
+

--- a/utilities/jumpbox/versions.tf
+++ b/utilities/jumpbox/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/utilities/main.tf
+++ b/utilities/main.tf
@@ -1,26 +1,27 @@
 module "jumpbox" {
   source      = "./jumpbox"
-  env         = "${var.env}"
-  domain_name = "${var.domain_name}"
+  env         = var.env
+  domain_name = var.domain_name
 
   # Turned off by default
-  enabled = "${var.jumpbox_enabled}"
+  enabled = var.jumpbox_enabled
 }
 
 module "teleport" {
   source      = "./teleport"
-  env         = "${var.env}"
-  domain_name = "${var.domain_name}"
-  gh_team     = "${var.teleport_github_team}"
+  env         = var.env
+  domain_name = var.domain_name
+  gh_team     = var.teleport_github_team
 }
 
 module "jenkins" {
   source        = "./jenkins"
-  env           = "${var.env}"
-  domain_name   = "${var.domain_name}"
-  ssh_proxy_sg  = "${module.teleport.security_group}"
-  workers       = "${var.jenkins_workers}"
-  jenkins_url   = "${var.jenkins_url}"
-  jenkins_image = "${var.jenkins_image}"
-  github_user   = "${var.jenkins_github_user}"
+  env           = var.env
+  domain_name   = var.domain_name
+  ssh_proxy_sg  = module.teleport.security_group
+  workers       = var.jenkins_workers
+  jenkins_url   = var.jenkins_url
+  jenkins_image = var.jenkins_image
+  github_user   = var.jenkins_github_user
 }
+

--- a/utilities/outputs.tf
+++ b/utilities/outputs.tf
@@ -1,4 +1,5 @@
 output "worker_iam_role" {
   description = "IAM role name for attaching additional policies for the worker with aws_iam_role_policy_attachment"
-  value       = "${module.jenkins.worker_iam_role}"
+  value       = module.jenkins.worker_iam_role
 }
+

--- a/utilities/teleport/data.tf
+++ b/utilities/teleport/data.tf
@@ -2,36 +2,37 @@
 ### Lookup resources already created by foundation
 #######
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
 
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
 data "aws_subnet" "application_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "app-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_subnet" "public_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "public-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
 data "aws_route53_zone" "external" {
-  name         = "${var.domain_name}"
+  name         = var.domain_name
   private_zone = false
 }
 
@@ -52,10 +53,10 @@ data "aws_secretsmanager_secret" "cluster_token" {
 }
 
 data "aws_security_group" "jumpbox" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env  = "${var.env}"
+  tags = {
+    env  = var.env
     app  = "utilities"
     Name = "jumpbox"
   }
@@ -70,3 +71,4 @@ data "aws_ami" "base" {
     values = ["adhoc_base*"]
   }
 }
+

--- a/utilities/teleport/main.tf
+++ b/utilities/teleport/main.tf
@@ -5,18 +5,18 @@
 
 # Public DNS name for client use to connect to proxies
 resource "aws_route53_record" "public" {
-  zone_id = "${data.aws_route53_zone.external.id}"
+  zone_id = data.aws_route53_zone.external.id
   name    = "teleport.${var.env}"
   type    = "CNAME"
   ttl     = 30
 
-  records = ["${aws_elb.proxy.dns_name}"]
+  records = [aws_elb.proxy.dns_name]
 }
 
 module "cert" {
   source      = "../../wildcard_cert"
-  env         = "${var.env}"
-  root_domain = "${var.domain_name}"
+  env         = var.env
+  root_domain = var.domain_name
 
   # Can't use aws_route53_record.public.fqdn here to prevent cycle with ELB
   domain = "teleport.${var.env}.${var.domain_name}"
@@ -28,23 +28,23 @@ resource "aws_route53_zone" "teleport" {
   comment = "${var.env} Teleport internal DNS"
 
   vpc {
-    vpc_id = "${data.aws_vpc.vpc.id}"
+    vpc_id = data.aws_vpc.vpc.id
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     Name      = "teleport-dns"
   }
 }
 
 resource "aws_route53_record" "auth_internal" {
-  zone_id = "${aws_route53_zone.teleport.id}"
+  zone_id = aws_route53_zone.teleport.id
   name    = "auth"
   type    = "CNAME"
   ttl     = 30
 
-  records = ["${aws_lb.auth.dns_name}"]
+  records = [aws_lb.auth.dns_name]
 }
 
 # A create a random cluster token at creation time. No rotation as of now.
@@ -55,7 +55,7 @@ resource "random_string" "cluster_token" {
 
 resource "aws_secretsmanager_secret_version" "cluster_token" {
   secret_id     = "${var.env}/teleport/cluster_token"
-  secret_string = "${random_string.cluster_token.result}"
+  secret_string = random_string.cluster_token.result
 }
 
 ### Shared IAM role for instances running teleport
@@ -86,4 +86,6 @@ resource "aws_iam_policy" "teleport_secrets" {
     ]
 }
 EOF
+
 }
+

--- a/utilities/teleport/outputs.tf
+++ b/utilities/teleport/outputs.tf
@@ -1,3 +1,4 @@
 output "security_group" {
-  value = "${aws_security_group.proxies.id}"
+  value = aws_security_group.proxies.id
 }
+

--- a/utilities/teleport/proxy.tf
+++ b/utilities/teleport/proxy.tf
@@ -11,8 +11,8 @@
 resource "aws_elb" "proxy" {
   name_prefix     = "telep-"
   internal        = false
-  security_groups = ["${aws_security_group.proxy_lb.id}"]
-  subnets         = ["${data.aws_subnet.public_subnet.*.id}"]
+  security_groups = [aws_security_group.proxy_lb.id]
+  subnets         = data.aws_subnet.public_subnet.*.id
 
   # Allow connections to idle for an hour
   idle_timeout = 3600
@@ -36,7 +36,7 @@ resource "aws_elb" "proxy" {
     instance_protocol  = "tcp"
     lb_port            = 443
     lb_protocol        = "ssl"
-    ssl_certificate_id = "${module.cert.arn}"
+    ssl_certificate_id = module.cert.arn
   }
 
   listener {
@@ -44,7 +44,7 @@ resource "aws_elb" "proxy" {
     instance_protocol  = "tcp"
     lb_port            = 3080
     lb_protocol        = "ssl"
-    ssl_certificate_id = "${module.cert.arn}"
+    ssl_certificate_id = module.cert.arn
   }
 
   health_check {
@@ -55,8 +55,8 @@ resource "aws_elb" "proxy" {
     interval            = 30
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "teleport"
     name      = "elb-teleport-proxy"
@@ -70,10 +70,10 @@ resource "aws_elb" "proxy" {
 # Security Group: world -> proxy
 resource "aws_security_group" "proxy_lb" {
   name_prefix = "teleport-proxy-lb-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "teleport"
     Name      = "world->teleport-proxy"
@@ -87,7 +87,7 @@ resource "aws_security_group_rule" "lb_webui_ingress" {
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.proxy_lb.id}"
+  security_group_id = aws_security_group.proxy_lb.id
 }
 
 resource "aws_security_group_rule" "lb_client_ingress" {
@@ -97,7 +97,7 @@ resource "aws_security_group_rule" "lb_client_ingress" {
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.proxy_lb.id}"
+  security_group_id = aws_security_group.proxy_lb.id
 }
 
 resource "aws_security_group_rule" "lb_ssh_ingress" {
@@ -107,7 +107,7 @@ resource "aws_security_group_rule" "lb_ssh_ingress" {
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.proxy_lb.id}"
+  security_group_id = aws_security_group.proxy_lb.id
 }
 
 resource "aws_security_group_rule" "lb_cluster_ingress" {
@@ -117,7 +117,7 @@ resource "aws_security_group_rule" "lb_cluster_ingress" {
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.proxy_lb.id}"
+  security_group_id = aws_security_group.proxy_lb.id
 }
 
 resource "aws_security_group_rule" "lb_egress" {
@@ -127,47 +127,47 @@ resource "aws_security_group_rule" "lb_egress" {
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.proxy_lb.id}"
+  security_group_id = aws_security_group.proxy_lb.id
 }
 
 #######
 # Proxy instances
 #######
 data "template_file" "user_data" {
-  count    = "${var.proxy_count}"
-  template = "${file("${path.module}/proxy-user-data.tmpl")}"
+  count    = var.proxy_count
+  template = file("${path.module}/proxy-user-data.tmpl")
 
-  vars {
+  vars = {
     nodename      = "teleport-proxy-${count.index}"
-    cluster_token = "${random_string.cluster_token.result}"
-    proxy_domain  = "${aws_route53_record.public.fqdn}"
+    cluster_token = random_string.cluster_token.result
+    proxy_domain  = aws_route53_record.public.fqdn
   }
 }
 
 resource "aws_instance" "proxies" {
-  count         = "${var.proxy_count}"
-  ami           = "${data.aws_ami.base.id}"
+  count         = var.proxy_count
+  ami           = data.aws_ami.base.id
   instance_type = "t3.micro"
-  key_name      = "${var.key_pair}"
+  key_name      = var.key_pair
 
-  user_data = "${element(data.template_file.user_data.*.rendered, count.index)}"
+  user_data = element(data.template_file.user_data.*.rendered, count.index)
 
   associate_public_ip_address = false
-  subnet_id                   = "${element(data.aws_subnet.application_subnet.*.id,count.index)}" #distribute instances across AZs
-  vpc_security_group_ids      = ["${aws_security_group.proxies.id}"]
+  subnet_id                   = element(data.aws_subnet.application_subnet.*.id, count.index) #distribute instances across AZs
+  vpc_security_group_ids      = [aws_security_group.proxies.id]
 
   lifecycle {
-    ignore_changes = ["ami"]
+    ignore_changes = [ami]
   }
 
   credit_specification {
     cpu_credits = "unlimited"
   }
 
-  tags {
+  tags = {
     Name      = "teleport-proxy-${count.index}"
     app       = "teleport"
-    env       = "${var.env}"
+    env       = var.env
     terraform = "true"
   }
 }
@@ -175,9 +175,9 @@ resource "aws_instance" "proxies" {
 # Add to target group to attach to LB
 
 resource "aws_elb_attachment" "proxy_ssh" {
-  count    = "${var.proxy_count}"
-  elb      = "${aws_elb.proxy.id}"
-  instance = "${element(aws_instance.proxies.*.id,count.index)}"
+  count    = var.proxy_count
+  elb      = aws_elb.proxy.id
+  instance = element(aws_instance.proxies.*.id, count.index)
 }
 
 #######
@@ -186,10 +186,10 @@ resource "aws_elb_attachment" "proxy_ssh" {
 
 resource "aws_security_group" "proxies" {
   name_prefix = "teleport-proxies-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "teleport"
     Name      = "teleport-proxies"
@@ -201,9 +201,9 @@ resource "aws_security_group_rule" "proxy_webui" {
   from_port                = 3080
   to_port                  = 3080
   protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.proxy_lb.id}"
+  source_security_group_id = aws_security_group.proxy_lb.id
 
-  security_group_id = "${aws_security_group.proxies.id}"
+  security_group_id = aws_security_group.proxies.id
 }
 
 resource "aws_security_group_rule" "proxy_ssh" {
@@ -211,9 +211,9 @@ resource "aws_security_group_rule" "proxy_ssh" {
   from_port                = 3023
   to_port                  = 3023
   protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.proxy_lb.id}"
+  source_security_group_id = aws_security_group.proxy_lb.id
 
-  security_group_id = "${aws_security_group.proxies.id}"
+  security_group_id = aws_security_group.proxies.id
 }
 
 resource "aws_security_group_rule" "proxy_cluster" {
@@ -221,9 +221,9 @@ resource "aws_security_group_rule" "proxy_cluster" {
   from_port                = 3024
   to_port                  = 3024
   protocol                 = "tcp"
-  source_security_group_id = "${aws_security_group.proxy_lb.id}"
+  source_security_group_id = aws_security_group.proxy_lb.id
 
-  security_group_id = "${aws_security_group.proxies.id}"
+  security_group_id = aws_security_group.proxies.id
 }
 
 # Must allow talking to the world to call out to AWS APIs
@@ -234,7 +234,7 @@ resource "aws_security_group_rule" "proxy_egress" {
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.proxies.id}"
+  security_group_id = aws_security_group.proxies.id
 }
 
 # Support for emergency jumpbox
@@ -243,7 +243,8 @@ resource "aws_security_group_rule" "jumpbox_proxy" {
   from_port                = 22
   to_port                  = 22
   protocol                 = "tcp"
-  source_security_group_id = "${data.aws_security_group.jumpbox.id}"
+  source_security_group_id = data.aws_security_group.jumpbox.id
 
-  security_group_id = "${aws_security_group.proxies.id}"
+  security_group_id = aws_security_group.proxies.id
 }
+

--- a/utilities/teleport/variables.tf
+++ b/utilities/teleport/variables.tf
@@ -25,3 +25,4 @@ variable "gh_team" {
   description = "OPTIONAL: the Github team to provide access to via Teleport"
   default     = "infrastructure-team"
 }
+

--- a/utilities/teleport/versions.tf
+++ b/utilities/teleport/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/utilities/teleport_subcluster/auth.tf
+++ b/utilities/teleport_subcluster/auth.tf
@@ -11,13 +11,13 @@ resource "aws_lb" "auth" {
   name_prefix                      = "telep-"
   internal                         = true
   load_balancer_type               = "network"
-  subnets                          = ["${data.aws_subnet.application_subnet.*.id}"]
+  subnets                          = data.aws_subnet.application_subnet.*.id
   enable_cross_zone_load_balancing = true
 
   ip_address_type = "ipv4"
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "teleport"
     name      = "lb-teleport-auth-internal"
@@ -30,13 +30,13 @@ resource "aws_lb_target_group" "auth" {
   name_prefix = "telep-"
   port        = 3025
   protocol    = "TCP"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
   target_type = "ip"
 
-  depends_on = ["aws_lb.auth"]
+  depends_on = [aws_lb.auth]
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "teleport"
     Name      = "lb-tg-telport-auth"
@@ -44,12 +44,12 @@ resource "aws_lb_target_group" "auth" {
 }
 
 resource "aws_lb_listener" "auth" {
-  load_balancer_arn = "${aws_lb.auth.arn}"
+  load_balancer_arn = aws_lb.auth.arn
   port              = 3025
   protocol          = "TCP"
 
   default_action {
-    target_group_arn = "${aws_lb_target_group.auth.arn}"
+    target_group_arn = aws_lb_target_group.auth.arn
     type             = "forward"
   }
 }
@@ -59,48 +59,48 @@ resource "aws_lb_listener" "auth" {
 #######
 
 data "template_file" "auth_user_data" {
-  count    = "${var.auth_count}"
-  template = "${file("${path.module}/auth-user-data.tmpl")}"
+  count    = var.auth_count
+  template = file("${path.module}/auth-user-data.tmpl")
 
-  vars {
+  vars = {
     nodename                 = "teleport-auth-${count.index}"
-    cluster_token            = "${random_string.cluster_token.result}"
-    region                   = "${data.aws_region.current.name}"
-    dynamo_table_name        = "${aws_dynamodb_table.teleport_state.name}"
-    dynamo_events_table_name = "${aws_dynamodb_table.teleport_events.name}"
-    s3_bucket                = "${aws_s3_bucket.recordings.id}"
-    cluster_name             = "${var.env}"
-    main_cluster             = "${var.main_cluster}"
-    main_cluster_token       = "${data.aws_secretsmanager_secret_version.main_cluster_token.secret_string}"
+    cluster_token            = random_string.cluster_token.result
+    region                   = data.aws_region.current.name
+    dynamo_table_name        = aws_dynamodb_table.teleport_state.name
+    dynamo_events_table_name = aws_dynamodb_table.teleport_events.name
+    s3_bucket                = aws_s3_bucket.recordings.id
+    cluster_name             = var.env
+    main_cluster             = var.main_cluster
+    main_cluster_token       = data.aws_secretsmanager_secret_version.main_cluster_token.secret_string
     main_cluster_url         = "teleport.${var.main_cluster}.${var.domain_name}"
   }
 }
 
 resource "aws_instance" "auths" {
-  count         = "${var.auth_count}"
-  ami           = "${data.aws_ami.base.id}"
+  count         = var.auth_count
+  ami           = data.aws_ami.base.id
   instance_type = "t3.nano"
-  key_name      = "${var.key_pair}"
+  key_name      = var.key_pair
 
-  iam_instance_profile = "${aws_iam_instance_profile.auth.name}"
-  user_data            = "${element(data.template_file.auth_user_data.*.rendered, count.index)}"
+  iam_instance_profile = aws_iam_instance_profile.auth.name
+  user_data            = element(data.template_file.auth_user_data.*.rendered, count.index)
 
   associate_public_ip_address = false
-  subnet_id                   = "${element(data.aws_subnet.application_subnet.*.id,count.index)}" #distribute instances across AZs
-  vpc_security_group_ids      = ["${aws_security_group.auths.id}"]
+  subnet_id                   = element(data.aws_subnet.application_subnet.*.id, count.index) #distribute instances across AZs
+  vpc_security_group_ids      = [aws_security_group.auths.id]
 
   lifecycle {
-    ignore_changes = ["ami"]
+    ignore_changes = [ami]
   }
 
   credit_specification {
     cpu_credits = "unlimited"
   }
 
-  tags {
+  tags = {
     Name      = "teleport-auth-${count.index}"
     app       = "teleport"
-    env       = "${var.env}"
+    env       = var.env
     terraform = "true"
   }
 }
@@ -108,9 +108,9 @@ resource "aws_instance" "auths" {
 # Add to target group to attach to LB
 
 resource "aws_lb_target_group_attachment" "auth" {
-  count            = "${var.auth_count}"
-  target_group_arn = "${aws_lb_target_group.auth.arn}"
-  target_id        = "${element(aws_instance.auths.*.private_ip,count.index)}"
+  count            = var.auth_count
+  target_group_arn = aws_lb_target_group.auth.arn
+  target_id        = element(aws_instance.auths.*.private_ip, count.index)
 }
 
 #######
@@ -119,10 +119,10 @@ resource "aws_lb_target_group_attachment" "auth" {
 
 resource "aws_security_group" "auths" {
   name_prefix = "teleport-auth-"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "teleport"
     Name      = "teleport-auth"
@@ -134,9 +134,9 @@ resource "aws_security_group_rule" "auth_webui" {
   from_port   = 3025
   to_port     = 3025
   protocol    = "tcp"
-  cidr_blocks = ["${data.aws_vpc.vpc.cidr_block}"]
+  cidr_blocks = [data.aws_vpc.vpc.cidr_block]
 
-  security_group_id = "${aws_security_group.auths.id}"
+  security_group_id = aws_security_group.auths.id
 }
 
 # Allow it to talk to any address to be able to hit AWS APIs for Dynamo, S3
@@ -147,7 +147,7 @@ resource "aws_security_group_rule" "auth_egress" {
   protocol    = "-1"
   cidr_blocks = ["0.0.0.0/0"]
 
-  security_group_id = "${aws_security_group.auths.id}"
+  security_group_id = aws_security_group.auths.id
 }
 
 # Support for emergency jumpbox
@@ -156,9 +156,9 @@ resource "aws_security_group_rule" "jumpbox_auth" {
   from_port                = 22
   to_port                  = 22
   protocol                 = "tcp"
-  source_security_group_id = "${data.aws_security_group.jumpbox.id}"
+  source_security_group_id = data.aws_security_group.jumpbox.id
 
-  security_group_id = "${aws_security_group.auths.id}"
+  security_group_id = aws_security_group.auths.id
 }
 
 #######
@@ -182,7 +182,10 @@ resource "aws_dynamodb_table" "teleport_state" {
   }
 
   lifecycle {
-    ignore_changes = ["read_capacity", "write_capacity"]
+    ignore_changes = [
+      read_capacity,
+      write_capacity,
+    ]
   }
 
   attribute {
@@ -200,8 +203,8 @@ resource "aws_dynamodb_table" "teleport_state" {
     enabled        = true
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "teleport"
     Name      = "teleport-auth-state"
@@ -230,7 +233,10 @@ resource "aws_dynamodb_table" "teleport_events" {
   }
 
   lifecycle {
-    ignore_changes = ["read_capacity", "write_capacity"]
+    ignore_changes = [
+      read_capacity,
+      write_capacity,
+    ]
   }
 
   attribute {
@@ -258,8 +264,8 @@ resource "aws_dynamodb_table" "teleport_events" {
     enabled        = true
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "teleport"
     Name      = "teleport-auth-audit"
@@ -282,14 +288,14 @@ resource "aws_s3_bucket" "recordings" {
   server_side_encryption_configuration {
     rule {
       apply_server_side_encryption_by_default {
-        kms_master_key_id = "${data.aws_kms_key.main.arn}" #TODO(bob) switch to unique, restricted key here?
+        kms_master_key_id = data.aws_kms_key.main.arn #TODO(bob) switch to unique, restricted key here?
         sse_algorithm     = "aws:kms"
       }
     }
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     app       = "teleport"
   }
@@ -301,7 +307,7 @@ resource "aws_s3_bucket" "recordings" {
 
 resource "aws_iam_instance_profile" "auth" {
   name = "${var.env}-teleport-auth"
-  role = "${aws_iam_role.auth.name}"
+  role = aws_iam_role.auth.name
 }
 
 // Auth instance profile and roles
@@ -320,12 +326,13 @@ resource "aws_iam_role" "auth" {
     ]
 }
 EOF
+
 }
 
 // Auth server uses DynamoDB as a backend, and this is to allow read/write from the dynamo tables
 resource "aws_iam_role_policy" "auth_dynamo" {
   name = "${var.env}-teleport-auth-dynamo"
-  role = "${aws_iam_role.auth.id}"
+  role = aws_iam_role.auth.id
 
   policy = <<EOF
 {
@@ -352,14 +359,15 @@ resource "aws_iam_role_policy" "auth_dynamo" {
     ]
 }
 EOF
+
 }
 
 // S3 for publishing session recordings to S3 encrypted bucket
 resource "aws_iam_role_policy" "auth_s3" {
-  name = "${var.env}-teleport-auth-s3"
-  role = "${aws_iam_role.auth.id}"
+name = "${var.env}-teleport-auth-s3"
+role = aws_iam_role.auth.id
 
-  policy = <<EOF
+policy = <<EOF
 {
    "Version": "2012-10-17",
    "Statement": [
@@ -387,5 +395,8 @@ resource "aws_iam_role_policy" "auth_s3" {
      }
    ]
  }
- EOF
+ 
+EOF
+
 }
+

--- a/utilities/teleport_subcluster/data.tf
+++ b/utilities/teleport_subcluster/data.tf
@@ -2,21 +2,22 @@
 ### Lookup resources already created by foundation
 #######
 
-data "aws_region" "current" {}
+data "aws_region" "current" {
+}
 
 data "aws_vpc" "vpc" {
-  tags {
-    env = "${var.env}"
+  tags = {
+    env = var.env
   }
 }
 
 data "aws_subnet" "application_subnet" {
   count  = 3
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
+  tags = {
     name = "app-sub-${count.index}"
-    env  = "${var.env}"
+    env  = var.env
   }
 }
 
@@ -33,10 +34,10 @@ data "aws_secretsmanager_secret_version" "main_cluster_token" {
 }
 
 data "aws_security_group" "jumpbox" {
-  vpc_id = "${data.aws_vpc.vpc.id}"
+  vpc_id = data.aws_vpc.vpc.id
 
-  tags {
-    env  = "${var.env}"
+  tags = {
+    env  = var.env
     app  = "utilities"
     Name = "jumpbox"
   }
@@ -51,3 +52,4 @@ data "aws_ami" "base" {
     values = ["adhoc_base*"]
   }
 }
+

--- a/utilities/teleport_subcluster/main.tf
+++ b/utilities/teleport_subcluster/main.tf
@@ -13,23 +13,23 @@ resource "aws_route53_zone" "teleport" {
   comment = "${var.env} Teleport internal DNS"
 
   vpc {
-    vpc_id = "${data.aws_vpc.vpc.id}"
+    vpc_id = data.aws_vpc.vpc.id
   }
 
-  tags {
-    env       = "${var.env}"
+  tags = {
+    env       = var.env
     terraform = "true"
     Name      = "teleport-dns"
   }
 }
 
 resource "aws_route53_record" "auth_internal" {
-  zone_id = "${aws_route53_zone.teleport.id}"
+  zone_id = aws_route53_zone.teleport.id
   name    = "auth"
   type    = "CNAME"
   ttl     = 30
 
-  records = ["${aws_lb.auth.dns_name}"]
+  records = [aws_lb.auth.dns_name]
 }
 
 # A create a random cluster token at creation time. No rotation as of now.
@@ -41,7 +41,7 @@ resource "random_string" "cluster_token" {
 
 resource "aws_secretsmanager_secret_version" "cluster_token" {
   secret_id     = "${var.env}/teleport/cluster_token"
-  secret_string = "${random_string.cluster_token.result}"
+  secret_string = random_string.cluster_token.result
 }
 
 ### Shared IAM role for instances running teleport
@@ -72,4 +72,6 @@ resource "aws_iam_policy" "teleport_secrets" {
     ]
 }
 EOF
+
 }
+

--- a/utilities/teleport_subcluster/outputs.tf
+++ b/utilities/teleport_subcluster/outputs.tf
@@ -1,3 +1,4 @@
 output "security_group" {
-  value = "${aws_security_group.proxies.id}"
+  value = aws_security_group.proxies.id
 }
+

--- a/utilities/teleport_subcluster/variables.tf
+++ b/utilities/teleport_subcluster/variables.tf
@@ -30,3 +30,4 @@ variable "main_cluster" {
   description = "The cluster_name (generally env) of the main cluster. Defaults to dev"
   default     = "dev"
 }
+

--- a/utilities/teleport_subcluster/versions.tf
+++ b/utilities/teleport_subcluster/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/utilities/variables.tf
+++ b/utilities/variables.tf
@@ -39,3 +39,4 @@ variable "teleport_github_team" {
   description = "GitHub team who can SSH via Teleport proxy"
   default     = "infrastructure-team"
 }
+

--- a/utilities/versions.tf
+++ b/utilities/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -15,3 +15,4 @@ variable "region" {
   description = "the preferred AWS region for resources."
   default     = "us-east-1"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/vpc/data.tf
+++ b/vpc/data.tf
@@ -1,1 +1,3 @@
-data "aws_availability_zones" "available" {}
+data "aws_availability_zones" "available" {
+}
+

--- a/vpc/outputs.tf
+++ b/vpc/outputs.tf
@@ -1,3 +1,4 @@
 output "id" {
-  value = "${aws_vpc.primary.id}"
+  value = aws_vpc.primary.id
 }
+

--- a/vpc/variables.tf
+++ b/vpc/variables.tf
@@ -6,3 +6,4 @@ variable "cidr" {
   description = "the CIDR block to provision for the VPC. it should be a /16 block"
   default     = "10.1.0.0/16"
 }
+

--- a/vpc/versions.tf
+++ b/vpc/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}

--- a/wildcard_cert/data.tf
+++ b/wildcard_cert/data.tf
@@ -3,6 +3,7 @@
 #######
 
 data "aws_route53_zone" "external" {
-  name         = "${var.root_domain}"
+  name         = var.root_domain
   private_zone = false
 }
+

--- a/wildcard_cert/main.tf
+++ b/wildcard_cert/main.tf
@@ -3,14 +3,14 @@
 #######
 
 resource "aws_acm_certificate" "domain" {
-  domain_name               = "${var.domain}"
+  domain_name               = var.domain
   subject_alternative_names = ["*.${var.domain}"]
 
   validation_method = "DNS"
 
-  tags {
+  tags = {
     terraform = "true"
-    env       = "${var.env}"
+    env       = var.env
     Name      = "wildcard-${var.domain}"
   }
 
@@ -20,16 +20,25 @@ resource "aws_acm_certificate" "domain" {
 }
 
 resource "aws_acm_certificate_validation" "domain" {
-  certificate_arn         = "${aws_acm_certificate.domain.arn}"
-  validation_record_fqdns = ["${aws_route53_record.validation.*.fqdn}"]
+  certificate_arn         = aws_acm_certificate.domain.arn
+  validation_record_fqdns = aws_route53_record.validation.*.fqdn
 }
 
 # Only need to validate the first record because the wildcard entry will use the same DNS record
 resource "aws_route53_record" "validation" {
   count   = "2"
-  name    = "${lookup(aws_acm_certificate.domain.domain_validation_options[count.index], "resource_record_name")}"
-  type    = "${lookup(aws_acm_certificate.domain.domain_validation_options[count.index], "resource_record_type")}"
-  zone_id = "${data.aws_route53_zone.external.id}"
-  records = ["${lookup(aws_acm_certificate.domain.domain_validation_options[count.index], "resource_record_value")}"]
+  name    = aws_acm_certificate.domain.domain_validation_options[count.index]["resource_record_name"]
+  type    = aws_acm_certificate.domain.domain_validation_options[count.index]["resource_record_type"]
+  zone_id = data.aws_route53_zone.external.id
+  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
+  # force an interpolation expression to be interpreted as a list by wrapping it
+  # in an extra set of list brackets. That form was supported for compatibilty in
+  # v0.11, but is no longer supported in Terraform v0.12.
+  #
+  # If the expression in the following list itself returns a list, remove the
+  # brackets to avoid interpretation as a list of lists. If the expression
+  # returns a single list item then leave it as-is and remove this TODO comment.
+  records = [aws_acm_certificate.domain.domain_validation_options[count.index]["resource_record_value"]]
   ttl     = 60
 }
+

--- a/wildcard_cert/main.tf
+++ b/wildcard_cert/main.tf
@@ -30,14 +30,6 @@ resource "aws_route53_record" "validation" {
   name    = aws_acm_certificate.domain.domain_validation_options[count.index]["resource_record_name"]
   type    = aws_acm_certificate.domain.domain_validation_options[count.index]["resource_record_type"]
   zone_id = data.aws_route53_zone.external.id
-  # TF-UPGRADE-TODO: In Terraform v0.10 and earlier, it was sometimes necessary to
-  # force an interpolation expression to be interpreted as a list by wrapping it
-  # in an extra set of list brackets. That form was supported for compatibilty in
-  # v0.11, but is no longer supported in Terraform v0.12.
-  #
-  # If the expression in the following list itself returns a list, remove the
-  # brackets to avoid interpretation as a list of lists. If the expression
-  # returns a single list item then leave it as-is and remove this TODO comment.
   records = [aws_acm_certificate.domain.domain_validation_options[count.index]["resource_record_value"]]
   ttl     = 60
 }

--- a/wildcard_cert/outputs.tf
+++ b/wildcard_cert/outputs.tf
@@ -1,3 +1,4 @@
 output "arn" {
-  value = "${aws_acm_certificate.domain.arn}"
+  value = aws_acm_certificate.domain.arn
 }
+

--- a/wildcard_cert/variables.tf
+++ b/wildcard_cert/variables.tf
@@ -9,3 +9,4 @@ variable "root_domain" {
 variable "domain" {
   description = "the Fully Qualified Domain Name for the new cert, e.g., beta.api.domain.name. Use .fqdn attribute from an aws_route53_record"
 }
+

--- a/wildcard_cert/versions.tf
+++ b/wildcard_cert/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
### Convert repo to Terraform 0.12 compatible code

Follows Hashicorp guidance: https://www.terraform.io/upgrade-guides/0-12.html

### Proposed changes:

- Uses automated tool to convert all tf files
- Updates Jenkins and test repo to work with Terraform 0.12

### Acceptance criteria validation
- [X] `terraform validate` for terraform 0.21.1 passes for the test directory

### Optional Details

After this is merged, we will need to switch back to the `infrastructure` repo to complete transition there. Then cut a new release here and merge there.