### PR TITLE
Update modules called in root main.tf to support AWS provider version 3.x syntax

### DIFF
--- a/autoscaling/ingress.tf
+++ b/autoscaling/ingress.tf
@@ -51,8 +51,9 @@ resource "aws_alb_listener_rule" "applications" {
   }
 
   condition {
-    field  = "host-header"
-    values = ["${var.application_name}.${var.base.domain_name}"]
+    host_header {
+      values = ["${var.application_name}.${var.base.domain_name}"]
+    }
   }
 }
 

--- a/fargate_cluster/ingress.tf
+++ b/fargate_cluster/ingress.tf
@@ -51,8 +51,9 @@ resource "aws_alb_listener_rule" "applications" {
   }
 
   condition {
-    field  = "host-header"
-    values = ["${var.application_name}.${var.base.domain_name}"]
+    host_header {
+      values = ["${var.application_name}.${var.base.domain_name}"]
+    }
   }
 }
 

--- a/ingress/main.tf
+++ b/ingress/main.tf
@@ -112,7 +112,7 @@ resource "aws_security_group_rule" "lb_ingress" {
   protocol  = "tcp"
 
   # If fronted by nginx, only accept traffic from inside the VPC
-  cidr_blocks = var.public ? ["0.0.0.0/0"] : ["${var.cidr_block}"]
+  cidr_blocks = var.public ? ["0.0.0.0/0"] : [var.cidr_block]
 
   security_group_id = aws_security_group.alb.id
 }

--- a/ingress/main.tf
+++ b/ingress/main.tf
@@ -79,7 +79,7 @@ resource "aws_alb_listener" "applications" {
     redirect {
       port        = "443"
       protocol    = "HTTPS"
-      host        = "${var.domain_name}"
+      host        = var.domain_name
       status_code = "HTTP_302"
     }
   }

--- a/instance/ingress.tf
+++ b/instance/ingress.tf
@@ -57,8 +57,9 @@ resource "aws_alb_listener_rule" "applications" {
   }
 
   condition {
-    field  = "host-header"
-    values = ["${var.application_name}.${var.base.domain_name}"]
+    host_header {
+      values = ["${var.application_name}.${var.base.domain_name}"]
+    }
   }
 }
 

--- a/wildcard_cert/main.tf
+++ b/wildcard_cert/main.tf
@@ -32,14 +32,13 @@ resource "aws_acm_certificate_validation" "domain" {
 
 # Only need to validate the first record because the wildcard entry will use the same DNS record
 resource "aws_route53_record" "validation" {
-  for_each = {
+  for_each = var.primary ? {
     for dvo in aws_acm_certificate.domain[0].domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
-  }  
-  count   = var.primary ? 1 : 0
+  } : {}
   name    = each.value.name
   type    = each.value.type
   zone_id = data.aws_route53_zone.external.id

--- a/wildcard_cert/main.tf
+++ b/wildcard_cert/main.tf
@@ -27,7 +27,7 @@ resource "aws_acm_certificate" "domain" {
 resource "aws_acm_certificate_validation" "domain" {
   count                   = var.primary ? 1 : 0
   certificate_arn         = aws_acm_certificate.domain[0].arn
-  validation_record_fqdns = [for record in aws_route53_record.validation[*] : record.fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
 }
 
 # Only need to validate the first record because the wildcard entry will use the same DNS record

--- a/wildcard_cert/main.tf
+++ b/wildcard_cert/main.tf
@@ -27,16 +27,23 @@ resource "aws_acm_certificate" "domain" {
 resource "aws_acm_certificate_validation" "domain" {
   count                   = var.primary ? 1 : 0
   certificate_arn         = aws_acm_certificate.domain[0].arn
-  validation_record_fqdns = aws_route53_record.validation[*].fqdn
+  validation_record_fqdns = [for record in aws_route53_record.validation[*] : record.fqdn]
 }
 
 # Only need to validate the first record because the wildcard entry will use the same DNS record
 resource "aws_route53_record" "validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.domain[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }  
   count   = var.primary ? 1 : 0
-  name    = aws_acm_certificate.domain[0].domain_validation_options[0]["resource_record_name"]
-  type    = aws_acm_certificate.domain[0].domain_validation_options[0]["resource_record_type"]
+  name    = each.value.name
+  type    = each.value.type
   zone_id = data.aws_route53_zone.external.id
-  records = [aws_acm_certificate.domain[0].domain_validation_options[0]["resource_record_value"]]
+  records = [each.value.record]
   ttl     = 60
 }
 

--- a/wildcard_cert/main.tf
+++ b/wildcard_cert/main.tf
@@ -38,6 +38,8 @@ resource "aws_route53_record" "validation" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
+    # Skips the domain if it doesn't contain a wildcard
+    if length(regexall("\\*\\..+", dvo.domain_name)) > 0
   } : {}
   name    = each.value.name
   type    = each.value.type


### PR DESCRIPTION
### Proposed changes:

- Update modules called in root main.tf to support AWS provider version 3.x syntax 
- Remove deprecation warnings about using 0.11 variable calling syntaxes